### PR TITLE
feat(HU-010): aprobacion individual de hijos en modelo flexible

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -20,6 +20,20 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
+        // 404 - Recurso no encontrado por lógica de negocio (servicio)
+        $this->renderable(function (\InvalidArgumentException $exception, $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return $this->jsonError($exception->getMessage(), 404);
+            }
+        });
+
+        // 422 - Regla de negocio violada (servicio)
+        $this->renderable(function (\LogicException $exception, $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return $this->jsonError($exception->getMessage(), 422);
+            }
+        });
+
         //  404 - Ruta o recurso no encontrado
         $this->renderable(function (NotFoundHttpException $exception, $request) {
             if ($request->expectsJson()) {

--- a/app/Http/Controllers/ElementApprovalController.php
+++ b/app/Http/Controllers/ElementApprovalController.php
@@ -155,4 +155,40 @@ class ElementApprovalController extends Controller
             ], 400);
         }
     }
+
+    public function approveIndividualChild(ElementApprovalRequest $request, int $padreId, int $hijoId): JsonResponse
+    {
+        $this->authorize('approve', \App\Models\ElementApproval::class);
+
+        $result = $this->approvalService->approveIndividualChild(
+            $padreId,
+            $hijoId,
+            $request->proceso_id
+        );
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Elemento hijo aprobado individualmente.',
+            'data'    => $result,
+        ], 201);
+    }
+
+    public function rejectIndividualChild(ElementApprovalRequest $request, int $padreId, int $hijoId): JsonResponse
+    {
+        $this->authorize('reject', \App\Models\ElementApproval::class);
+
+        $result = $this->approvalService->rejectIndividualChild(
+            $padreId,
+            $hijoId,
+            $request->proceso_id,
+            $request->comentario,
+            $request->nueva_fecha_limite
+        );
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Elemento hijo rechazado individualmente.',
+            'data'    => $result,
+        ], 201);
+    }
 }

--- a/app/Http/Requests/ElementApprovalRequest.php
+++ b/app/Http/Requests/ElementApprovalRequest.php
@@ -16,9 +16,10 @@ class ElementApprovalRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'proceso_id'   => ['required', 'integer', 'exists:PROCESO,proceso_id'],
-            'comentario'   => ['nullable', 'string', 'max:100'],
-            'fecha_limite' => ['nullable', 'date', 'after:now'],
+            'proceso_id'         => ['required', 'integer', 'exists:PROCESO,proceso_id'],
+            'comentario'         => ['nullable', 'string', 'max:100'],
+            'fecha_limite'       => ['nullable', 'date', 'after:now'],
+            'nueva_fecha_limite' => ['nullable', 'date', 'after:now'],
         ];
     }
 

--- a/app/Models/ElementApproval.php
+++ b/app/Models/ElementApproval.php
@@ -18,6 +18,11 @@ class ElementApproval extends Model
         'usuario_id',
         'estado',
         'comentario',
+        'nueva_fecha_limite',// para almacenar la nueva fecha límite propuesta por el usuario en caso de rechazo
+    ];
+
+    protected $casts = [
+        'nueva_fecha_limite' => 'date',// para asegurarnos de que se trate como una fecha al acceder a este campo
     ];
 
     /**

--- a/app/Observers/ElementAssignmentObserver.php
+++ b/app/Observers/ElementAssignmentObserver.php
@@ -2,8 +2,10 @@
 
 namespace App\Observers;
 
+use App\Models\ElementApproval;
 use App\Models\ElementAssignment;
 use App\Models\ElementExtensionRequest;
+use App\Models\StructureElement;
 use Illuminate\Support\Facades\Log;
 
 class ElementAssignmentObserver
@@ -38,5 +40,41 @@ class ElementAssignmentObserver
                 'nuevo_estado'           => $nuevoEstado,
             ]);
         }
+    }
+
+    /**
+     * HU-010 flexible: cuando el responsable marca su asignación como Completado
+     * y existe una APROBACION_ELEMENTO rechazada para ese elemento+proceso,
+     * el bloque padre incompleto vuelve a 'pendiente' para que el evaluador sepa
+     * que hay nuevas correcciones listas para revisar.
+     */
+    public function updated(ElementAssignment $assignment): void
+    {
+        if (!$assignment->wasChanged('estado')) {
+            return;
+        }
+
+        if ($assignment->estado !== ElementAssignment::ESTADO_COMPLETADO) {
+            return;
+        }
+
+        $tieneRechazo = ElementApproval::where('elemento_id', $assignment->elemento_id)
+            ->where('proceso_id', $assignment->proceso_id)
+            ->where('estado', 'rechazado')
+            ->exists();
+
+        if (!$tieneRechazo) {
+            return;
+        }
+
+        $elemento = StructureElement::find($assignment->elemento_id);
+        if (!$elemento || !$elemento->padre_id) {
+            return;
+        }
+
+        ElementApproval::where('elemento_id', $elemento->padre_id)
+            ->where('proceso_id', $assignment->proceso_id)
+            ->where('estado', 'incompleto')
+            ->update(['estado' => 'pendiente']);
     }
 }

--- a/app/Services/ElementApprovalService.php
+++ b/app/Services/ElementApprovalService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\ElementApproval;
+use App\Models\ElementAssignment;
 use App\Models\StructureElement;
 use App\Events\ElementApproved;
 use App\Events\ElementRejected;
@@ -100,6 +101,53 @@ class ElementApprovalService
     }
 
     /**
+     * Recalcula y persiste el estado del bloque padre según las decisiones
+     * individuales de sus hijos directos activos.
+     *
+     * Reglas (equivalente a recalculateBlockState en CriterionApprovalService):
+     *   - Todos aprobados                         → 'aprobado'
+     *   - Todos rechazados                        → 'rechazado'
+     *   - Al menos 1 rechazado (no todos iguales) → 'incompleto'
+     *   - Ninguna decisión tomada aún             → 'pendiente'
+     */
+    public function recalculateParentState(int $padreId, int $procesoId): void
+    {
+        $block = ElementApproval::where('elemento_id', $padreId)
+            ->where('proceso_id', $procesoId)
+            ->first();
+
+        if (!$block) {
+            return;
+        }
+
+        $childIds = StructureElement::where('padre_id', $padreId)
+            ->where('activo', true)
+            ->pluck('elemento_id');
+
+        $total    = $childIds->count();
+        $approved = ElementApproval::whereIn('elemento_id', $childIds)
+            ->where('proceso_id', $procesoId)
+            ->where('estado', 'aprobado')
+            ->count();
+        $rejected = ElementApproval::whereIn('elemento_id', $childIds)
+            ->where('proceso_id', $procesoId)
+            ->where('estado', 'rechazado')
+            ->count();
+
+        if ($total > 0 && $approved === $total) {
+            $block->estado = 'aprobado';
+        } elseif ($total > 0 && $rejected === $total) {
+            $block->estado = 'rechazado';
+        } elseif ($rejected >= 1) {
+            $block->estado = 'incompleto';
+        } else {
+            $block->estado = 'pendiente';
+        }
+
+        $block->save();
+    }
+
+    /**
      * Aprueba un elemento y en cascada todos sus descendientes activos.
      *
      * - Si pasas una FUENTE (hoja): aprueba solo esa fuente.
@@ -191,7 +239,7 @@ class ElementApprovalService
             foreach ($allIds as $id) {
                 $approval = ElementApproval::updateOrCreate(
                     ['elemento_id' => $id, 'proceso_id' => $procesoId],
-                    ['usuario_id' => $usuarioId, 'estado' => 'rechazado', 'comentario' => $comentario]
+                    ['usuario_id' => $usuarioId, 'estado' => 'rechazado', 'comentario' => $comentario, 'nueva_fecha_limite' => $fechaLimite]
                 )->load(['elemento', 'process', 'user']);
 
                 if ($id === $elementoId) {
@@ -201,10 +249,14 @@ class ElementApprovalService
                 }
             }
 
-            // TODO HU-009: actualizar ELEMENTO_ASIGNACION a estado Rechazado:
-            // ElementAssignment::whereIn('elemento_id', $allIds)
-            //     ->where('proceso_id', $procesoId)
-            //     ->update(['estado' => 'Rechazado', 'comentario' => $comentario, 'fecha_limite' => $fechaLimite]);
+            // Resetear asignaciones a Pendiente para que los responsables reenvíen
+            $assignmentUpdate = ['estado' => ElementAssignment::ESTADO_PENDIENTE];
+            if ($fechaLimite !== null) {
+                $assignmentUpdate['fecha_limite'] = $fechaLimite;
+            }
+            ElementAssignment::whereIn('elemento_id', $allIds)
+                ->where('proceso_id', $procesoId)
+                ->update($assignmentUpdate);
 
             return ['raiz' => $root, 'cascada' => $cascada];
         });
@@ -219,5 +271,179 @@ class ElementApprovalService
         );
 
         return $result;
+    }
+
+    // -----------------------------------------------------------------------
+    // Aprobación / rechazo individual de hijo (fuente dentro de pauta)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Aprueba un elemento hijo (fuente) individualmente dentro del bloque padre.
+     *
+     * Regla de bloqueo: si el bloque padre está 'incompleto', un hijo ya
+     * 'aprobado' no puede volver a tocarse.
+     *
+     * Tras guardar, recalcula el estado del bloque padre automáticamente.
+     *
+     * @throws \InvalidArgumentException Si el hijo no pertenece al padre o está inactivo.
+     * @throws \LogicException           Si el hijo ya está aprobado y el bloque es 'incompleto'.
+     */
+    public function approveIndividualChild(
+        int $padreId,
+        int $hijoId,
+        int $procesoId
+    ): array {
+        // Validaciones fuera de la transacción para que el Handler las capture directamente
+        $hijo = StructureElement::where('elemento_id', $hijoId)
+            ->where('padre_id', $padreId)
+            ->where('activo', true)
+            ->firstOrFail();
+
+        if (!$hijo) {
+            throw new \InvalidArgumentException(
+                'El elemento hijo no existe, no pertenece al padre indicado o está inactivo.'
+            );
+        }
+
+        $padreApproval = ElementApproval::where('elemento_id', $padreId)
+            ->where('proceso_id', $procesoId)
+            ->first();
+
+        $existing = ElementApproval::where('elemento_id', $hijoId)
+            ->where('proceso_id', $procesoId)
+            ->first();
+
+        if ($existing && $existing->estado === 'aprobado' && $padreApproval && $padreApproval->estado === 'incompleto') {
+            throw new \LogicException(
+                'Este elemento ya fue aprobado y está bloqueado mientras el bloque tenga estado incompleto.'
+            );
+        }
+
+        return DB::transaction(function () use ($padreId, $hijoId, $procesoId, $hijo) {
+            $usuarioId = Auth::id();
+
+            $parentApproval = ElementApproval::firstOrCreate(
+                ['elemento_id' => $padreId, 'proceso_id' => $procesoId],
+                ['usuario_id' => $usuarioId, 'estado' => 'pendiente', 'comentario' => null]
+            );
+
+            $childApproval = ElementApproval::updateOrCreate(
+                ['elemento_id' => $hijoId, 'proceso_id' => $procesoId],
+                [
+                    'usuario_id' => $usuarioId,
+                    'estado'     => 'aprobado',
+                    'comentario' => null,
+                ]
+            );
+
+            $this->recalculateParentState($padreId, $procesoId);
+
+            $padre = StructureElement::find($padreId);
+            AuditLogService::log(
+                'aprobar',
+                "Hijo '{$hijo->nomenclatura}' aprobado individualmente en bloque '{$padre->nomenclatura}'",
+                'Aprobación Elements'
+            );
+
+            return [
+                'padre_approval' => $parentApproval->fresh()->load(['elemento', 'process', 'user']),
+                'hijo_approval'  => $childApproval->load(['elemento']),
+            ];
+        });
+    }
+
+    /**
+     * Rechaza un elemento hijo (fuente) individualmente dentro del bloque padre.
+     *
+     * Regla de bloqueo: si el bloque padre está 'incompleto', un hijo ya
+     * 'aprobado' no puede cambiarse a rechazado.
+     *
+     * Al rechazar se guarda el comentario en APROBACION_ELEMENTO del hijo
+     * y se actualiza ELEMENTO_ASIGNACION con la nueva fecha límite (si se
+     * proporciona), reseteando el estado de la asignación a 'Pendiente'.
+     *
+     * Tras guardar, recalcula el estado del bloque padre automáticamente.
+     *
+     * @throws \InvalidArgumentException Si el hijo no pertenece al padre o está inactivo.
+     * @throws \LogicException           Si el hijo ya está aprobado y el bloque es 'incompleto'.
+     */
+    public function rejectIndividualChild(
+        int $padreId,
+        int $hijoId,
+        int $procesoId,
+        ?string $comentario = null,
+        ?string $nuevaFechaLimite = null
+    ): array {
+        // Validaciones fuera de la transacción para que el Handler las capture directamente
+        $hijo = StructureElement::where('elemento_id', $hijoId)
+            ->where('padre_id', $padreId)
+            ->where('activo', true)
+            ->first();
+
+        if (!$hijo) {
+            throw new \InvalidArgumentException(
+                'El elemento hijo no existe, no pertenece al padre indicado o está inactivo.'
+            );
+        }
+
+        $padreApproval = ElementApproval::where('elemento_id', $padreId)
+            ->where('proceso_id', $procesoId)
+            ->first();
+
+        $existing = ElementApproval::where('elemento_id', $hijoId)
+            ->where('proceso_id', $procesoId)
+            ->first();
+
+        if ($existing && $existing->estado === 'aprobado' && $padreApproval && $padreApproval->estado === 'incompleto') {
+            throw new \LogicException(
+                'Este elemento ya fue aprobado y está bloqueado mientras el bloque tenga estado incompleto.'
+            );
+        }
+
+        return DB::transaction(function () use ($padreId, $hijoId, $procesoId, $comentario, $nuevaFechaLimite, $hijo) {
+            $usuarioId = Auth::id();
+
+            $parentApproval = ElementApproval::firstOrCreate(
+                ['elemento_id' => $padreId, 'proceso_id' => $procesoId],
+                ['usuario_id' => $usuarioId, 'estado' => 'pendiente', 'comentario' => null]
+            );
+
+            $childApproval = ElementApproval::updateOrCreate(
+                ['elemento_id' => $hijoId, 'proceso_id' => $procesoId],
+                [
+                    'usuario_id'         => $usuarioId,
+                    'estado'             => 'rechazado',
+                    'comentario'         => $comentario,
+                    'nueva_fecha_limite' => $nuevaFechaLimite,
+                ]
+            );
+
+            // Devolver la asignación al responsable: resetear estado + guardar observación + nueva fecha
+            $assignmentUpdate = ['estado' => ElementAssignment::ESTADO_PENDIENTE];
+            if ($comentario !== null) {
+                $assignmentUpdate['comentario'] = $comentario;
+            }
+            if ($nuevaFechaLimite !== null) {
+                $assignmentUpdate['fecha_limite'] = $nuevaFechaLimite;
+            }
+
+            ElementAssignment::where('elemento_id', $hijoId)
+                ->where('proceso_id', $procesoId)
+                ->update($assignmentUpdate);
+
+            $this->recalculateParentState($padreId, $procesoId);
+
+            $padre = StructureElement::find($padreId);
+            AuditLogService::log(
+                'rechazar',
+                "Hijo '{$hijo->nomenclatura}' rechazado individualmente en bloque '{$padre->nomenclatura}'",
+                'Aprobación Elements'
+            );
+
+            return [
+                'padre_approval' => $parentApproval->fresh()->load(['elemento', 'process', 'user']),
+                'hijo_approval'  => $childApproval->load(['elemento']),
+            ];
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -49,6 +49,20 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        // 404 - Elemento no encontrado por lógica de negocio
+        $exceptions->render(function (\InvalidArgumentException $e, Request $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return response()->json(['status' => 'error', 'code' => 404, 'message' => $e->getMessage()], 404);
+            }
+        });
+
+        // 422 - Regla de negocio violada (elemento bloqueado, estado inválido, etc.)
+        $exceptions->render(function (\LogicException $e, Request $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return response()->json(['status' => 'error', 'code' => 422, 'message' => $e->getMessage()], 422);
+            }
+        });
+
         // Forzar respuestas JSON para todas las rutas /api/*
         $exceptions->render(function (AuthenticationException $e, Request $request) {
             if ($request->is('api/*')) {

--- a/database/migrations/059_add_pending_status_to_element_approvals.php
+++ b/database/migrations/059_add_pending_status_to_element_approvals.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * HU-010 (flexible): Agrega el estado 'pendiente' al enum de APROBACION_ELEMENTO.
+ *
+ * 'pendiente' es el estado inicial: ninguna aprobación/rechazo registrado aún.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE APROBACION_ELEMENTO MODIFY COLUMN estado ENUM('aprobado', 'rechazado', 'pendiente') NOT NULL");
+    }
+
+    public function down(): void
+    {
+        DB::table('APROBACION_ELEMENTO')->where('estado', 'pendiente')->delete();
+        DB::statement("ALTER TABLE APROBACION_ELEMENTO MODIFY COLUMN estado ENUM('aprobado', 'rechazado') NOT NULL");
+    }
+};

--- a/database/migrations/060_add_incomplete_status_to_element_approvals.php
+++ b/database/migrations/060_add_incomplete_status_to_element_approvals.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * HU-010 (flexible): Agrega el estado 'incompleto' al enum de APROBACION_ELEMENTO.
+ *
+ * 'incompleto' indica que el elemento tiene al menos 1 hijo rechazado
+ * individualmente pero no todos están en el mismo estado. El bloque bloquea
+ * los hijos aprobados y espera corrección de los rechazados.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE APROBACION_ELEMENTO MODIFY COLUMN estado ENUM('aprobado', 'rechazado', 'pendiente', 'incompleto') NOT NULL");
+    }
+
+    public function down(): void
+    {
+        DB::table('APROBACION_ELEMENTO')->where('estado', 'incompleto')->update(['estado' => 'pendiente']);
+        DB::statement("ALTER TABLE APROBACION_ELEMENTO MODIFY COLUMN estado ENUM('aprobado', 'rechazado', 'pendiente') NOT NULL");
+    }
+};

--- a/database/migrations/061_add_nueva_fecha_limite_to_element_approvals.php
+++ b/database/migrations/061_add_nueva_fecha_limite_to_element_approvals.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('APROBACION_ELEMENTO', function (Blueprint $table) {
+            $table->date('nueva_fecha_limite')->nullable()->after('comentario');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('APROBACION_ELEMENTO', function (Blueprint $table) {
+            $table->dropColumn('nueva_fecha_limite');
+        });
+    }
+};

--- a/docs/HU010_APROBACION_MODELO_FLEXIBLE.md
+++ b/docs/HU010_APROBACION_MODELO_FLEXIBLE.md
@@ -1,0 +1,371 @@
+# HU-010 — Aprobación de Bloques en Modelo Flexible
+
+> **Rama:** `hu10_notificaciones_estados_modelo_cristina`
+> **Fecha de implementación:** 4 de abril de 2026
+
+---
+
+## 1. Descripción General
+
+Permite que el **Evaluador** apruebe o rechace individualmente cada elemento hijo (componente, fuente, etc.) dentro de un bloque padre en el **modelo flexible (ELEMENTO)**, sin pasar por criterios ni evidencias.
+
+El sistema gestiona automáticamente el estado del bloque padre según las decisiones tomadas sobre sus hijos.
+
+---
+
+## 2. Tabla Principal Afectada
+
+| Tabla | Descripción |
+|---|---|
+| `APROBACION_ELEMENTO` | Registro de aprobación/rechazo de cada elemento en un proceso |
+
+### Columnas relevantes en `APROBACION_ELEMENTO`
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `aprobacion_elemento_id` | INT PK | Identificador principal |
+| `elemento_id` | INT FK | Elemento aprobado/rechazado |
+| `proceso_id` | INT FK | Proceso de acreditación |
+| `usuario_id` | INT FK | Evaluador que tomó la decisión |
+| `estado` | ENUM | `pendiente`, `aprobado`, `rechazado`, `incompleto` |
+| `comentario` | VARCHAR(100) | Motivo del rechazo (opcional en aprobación) |
+| `nueva_fecha_limite` | DATE | Nueva fecha límite propuesta al rechazar (opcional) |
+
+---
+
+## 3. Migraciones Aplicadas
+
+| # | Archivo | Descripción |
+|---|---|---|
+| 059 | `059_add_pending_status_to_element_approvals.php` | Agrega valor `pendiente` al ENUM `estado` |
+| 060 | `060_add_incomplete_status_to_element_approvals.php` | Agrega valor `incompleto` al ENUM `estado` |
+| 061 | `061_add_nueva_fecha_limite_to_element_approvals.php` | Agrega columna `nueva_fecha_limite DATE NULL` |
+
+---
+
+## 4. Lógica de Estados del Bloque Padre
+
+Cada vez que se aprueba o rechaza un hijo individual, el servicio **recalcula automáticamente** el estado del bloque padre mediante `recalculateParentState()`.
+
+| Condición sobre los hijos directos activos | Estado del padre |
+|---|---|
+| Todos aprobados | `aprobado` |
+| Todos rechazados | `rechazado` |
+| Al menos 1 rechazado (mezcla) | `incompleto` |
+| Ninguna decisión tomada aún | `pendiente` |
+
+---
+
+## 5. Regla de Bloqueo
+
+Cuando el bloque padre está en estado **`incompleto`**, un hijo que ya fue **`aprobado`** **no puede modificarse** (ni re-aprobarse ni rechazarse).
+
+- Si se intenta, el servicio lanza `\LogicException` → respuesta `422 Unprocessable Entity`.
+
+---
+
+## 6. Observer: Reset automático `incompleto → pendiente`
+
+**Clase:** `App\Observers\ElementAssignmentObserver`  
+**Evento observado:** `updated` en `ElementAssignment`
+
+**Flujo:**
+1. El responsable corrige su trabajo y marca la `ELEMENTO_ASIGNACION` como `Completado`.
+2. El Observer detecta que ese elemento tiene una `APROBACION_ELEMENTO` en estado `rechazado`.
+3. Si el bloque padre tiene estado `incompleto`, lo resetea automáticamente a `pendiente`.
+4. El evaluador ve el bloque como pendiente de nueva revisión.
+
+**Propósito:** Notificar al evaluador que el responsable ya corrigió el trabajo rechazado y está listo para re-evaluar.
+
+---
+
+## 7. Archivos Modificados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `app/Models/ElementApproval.php` | Agregado `nueva_fecha_limite` a `$fillable` y `$casts` |
+| `app/Http/Requests/ElementApprovalRequest.php` | Agregada regla `nueva_fecha_limite` |
+| `app/Services/ElementApprovalService.php` | Nuevos métodos `approveIndividualChild`, `rejectIndividualChild`, `recalculateParentState` |
+| `app/Http/Controllers/ElementApprovalController.php` | Nuevos métodos `approveIndividualChild`, `rejectIndividualChild` (thin controller) |
+| `app/Observers/ElementAssignmentObserver.php` | Nuevo método `updated()` para reset `incompleto → pendiente` |
+| `routes/api.php` | 2 rutas nuevas para aprobación/rechazo individual de hijo |
+| `bootstrap/app.php` | Handlers de excepción `LogicException → 422` e `InvalidArgumentException → 404` |
+
+---
+
+## 8. Endpoints
+
+### 8.1 Endpoints Preexistentes (Modelo Flexible — Cascada)
+
+Estos endpoints aprueban/rechazan un elemento **y todos sus descendientes activos** en cascada.
+
+---
+
+#### `GET /api/aprobaciones-elementos`
+Lista todas las aprobaciones de elementos.
+
+**Permiso requerido:** `viewAny ElementApproval`  
+**Query params opcionales:**
+
+| Param | Tipo | Descripción |
+|---|---|---|
+| `estado` | string | Filtrar por estado: `pendiente`, `aprobado`, `rechazado`, `incompleto` |
+
+**Respuesta 200:**
+```json
+{
+    "success": true,
+    "data": [
+        {
+            "aprobacion_elemento_id": 1,
+            "elemento_id": 19,
+            "proceso_id": 33,
+            "usuario_id": 56,
+            "estado": "incompleto",
+            "comentario": null,
+            "nueva_fecha_limite": null
+        }
+    ]
+}
+```
+
+---
+
+#### `GET /api/aprobaciones-elementos/{aprobacionId}`
+Obtiene una aprobación específica, incluyendo las aprobaciones de sus hijos.
+
+**Permiso requerido:** `view ElementApproval`
+
+**Respuesta 200:**
+```json
+{
+    "success": true,
+    "data": {
+        "aprobacion_elemento_id": 5,
+        "elemento_id": 19,
+        "estado": "incompleto",
+        "hijos": [...]
+    }
+}
+```
+
+---
+
+#### `POST /api/elementos/{elementoId}/aprobar`
+Aprueba un elemento y en **cascada** todos sus hijos activos.
+
+**Permiso requerido:** `approve ElementApproval`  
+**Throttle:** 10 req/min
+
+**Body:**
+```json
+{
+    "proceso_id": 33,
+    "comentario": "Todo correcto"
+}
+```
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `proceso_id` | integer | ✅ | ID del proceso activo |
+| `comentario` | string (max 100) | ❌ | Observación del evaluador |
+
+**Respuesta 201:**
+```json
+{
+    "success": true,
+    "message": "Elemento aprobado exitosamente.",
+    "data": {
+        "raiz": { "elemento_id": 19, "estado": "aprobado" },
+        "cascada": [{ "elemento_id": 20, "estado": "aprobado" }, ...]
+    }
+}
+```
+
+---
+
+#### `POST /api/elementos/{elementoId}/rechazar`
+Rechaza un elemento y en **cascada** todos sus hijos activos. Resetea las `ELEMENTO_ASIGNACION` a `Pendiente`.
+
+**Permiso requerido:** `reject ElementApproval`  
+**Throttle:** 10 req/min
+
+**Body:**
+```json
+{
+    "proceso_id": 33,
+    "comentario": "Faltan evidencias de respaldo",
+    "fecha_limite": "2026-06-01"
+}
+```
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `proceso_id` | integer | ✅ | ID del proceso activo |
+| `comentario` | string (max 100) | ❌ | Motivo del rechazo |
+| `fecha_limite` | date (after:now) | ❌ | Nueva fecha límite para correcciones |
+
+**Respuesta 201:**
+```json
+{
+    "success": true,
+    "message": "Elemento rechazado exitosamente.",
+    "data": {
+        "raiz": { "elemento_id": 19, "estado": "rechazado" },
+        "cascada": [{ "elemento_id": 20, "estado": "rechazado" }, ...]
+    }
+}
+```
+
+---
+
+### 8.2 Endpoints Nuevos (HU-010 — Aprobación Individual de Hijo)
+
+Permiten evaluar **un hijo a la vez** dentro de un bloque padre, calculando automáticamente el estado del padre.
+
+---
+
+#### `POST /api/elementos/{padreId}/hijos/{hijoId}/aprobar`
+Aprueba un elemento hijo individualmente dentro del bloque padre.
+
+**Permiso requerido:** `approve ElementApproval`  
+**Throttle:** 10 req/min
+
+**Parámetros de ruta:**
+
+| Param | Descripción |
+|---|---|
+| `padreId` | `elemento_id` del bloque padre |
+| `hijoId` | `elemento_id` del hijo a aprobar |
+
+**Body:**
+```json
+{
+    "proceso_id": 33
+}
+```
+
+| Campo | Tipo | Requerido |
+|---|---|---|
+| `proceso_id` | integer | ✅ |
+
+**Respuesta 201:**
+```json
+{
+    "success": true,
+    "message": "Elemento hijo aprobado individualmente.",
+    "data": {
+        "padre_approval": {
+            "elemento_id": 19,
+            "estado": "aprobado"
+        },
+        "hijo_approval": {
+            "elemento_id": 21,
+            "estado": "aprobado"
+        }
+    }
+}
+```
+
+**Errores posibles:**
+
+| Código | Causa |
+|---|---|
+| `404` | El hijo no existe, no pertenece al padre o está inactivo |
+| `422` | El hijo ya fue aprobado y el bloque padre está `incompleto` (regla de bloqueo) |
+| `403` | Sin permiso `approve ElementApproval` |
+| `422` | Falla de validación del `FormRequest` |
+
+---
+
+#### `POST /api/elementos/{padreId}/hijos/{hijoId}/rechazar`
+Rechaza un elemento hijo individualmente dentro del bloque padre. Guarda comentario y nueva fecha límite en `APROBACION_ELEMENTO`, y resetea la `ELEMENTO_ASIGNACION` del hijo a `Pendiente`.
+
+**Permiso requerido:** `reject ElementApproval`  
+**Throttle:** 10 req/min
+
+**Parámetros de ruta:**
+
+| Param | Descripción |
+|---|---|
+| `padreId` | `elemento_id` del bloque padre |
+| `hijoId` | `elemento_id` del hijo a rechazar |
+
+**Body:**
+```json
+{
+    "proceso_id": 33,
+    "comentario": "Falta completar la sección 2",
+    "nueva_fecha_limite": "2026-06-15"
+}
+```
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `proceso_id` | integer | ✅ | ID del proceso activo |
+| `comentario` | string (max 100) | ❌ | Motivo del rechazo |
+| `nueva_fecha_limite` | date (after:now) | ❌ | Nueva fecha límite para la corrección |
+
+**Respuesta 201:**
+```json
+{
+    "success": true,
+    "message": "Elemento hijo rechazado individualmente.",
+    "data": {
+        "padre_approval": {
+            "elemento_id": 19,
+            "estado": "incompleto"
+        },
+        "hijo_approval": {
+            "elemento_id": 20,
+            "estado": "rechazado",
+            "comentario": "Falta completar la sección 2",
+            "nueva_fecha_limite": "2026-06-15"
+        }
+    }
+}
+```
+
+**Errores posibles:**
+
+| Código | Causa |
+|---|---|
+| `404` | El hijo no existe, no pertenece al padre o está inactivo |
+| `422` | El hijo ya fue aprobado y el bloque padre está `incompleto` (regla de bloqueo) |
+| `403` | Sin permiso `reject ElementApproval` |
+| `422` | Falla de validación del `FormRequest` |
+
+---
+
+## 9. Efectos Secundarios al Rechazar un Hijo
+
+Cuando se rechaza un hijo con `POST .../hijos/{hijoId}/rechazar`:
+
+1. Se crea/actualiza `APROBACION_ELEMENTO` del hijo con `estado = rechazado`.
+2. Se actualizan las `ELEMENTO_ASIGNACION` del hijo en ese proceso:
+   - `estado → Pendiente`
+   - `comentario → {comentario}` (si se envió)
+   - `fecha_limite → {nueva_fecha_limite}` (si se envió)
+3. Se recalcula el estado del bloque padre.
+
+---
+
+## 10. Flujo Completo de Uso
+
+```
+1. Evaluador: POST /api/elementos/19/hijos/21/aprobar     → hijo 21 = aprobado, padre 19 = pendiente (1 de 2 hijos)
+2. Evaluador: POST /api/elementos/19/hijos/20/rechazar    → hijo 20 = rechazado, padre 19 = incompleto
+3. Responsable: PUT /api/elementos-asignaciones/20        → estado: "Completado"
+   └── Observer detecta: hijo 20 rechazado + padre incompleto
+   └── Padre 19 reseteado → pendiente  (evaluador sabe que hay correcciones listas)
+4. Evaluador: POST /api/elementos/19/hijos/20/aprobar     → hijo 20 = aprobado, padre 19 = aprobado (todos aprobados)
+```
+
+---
+
+## 11. Notas Técnicas
+
+- **Thin controller:** Los métodos `approveIndividualChild` y `rejectIndividualChild` en el controller tienen 3-4 líneas; toda la lógica está en `ElementApprovalService`.
+- **Excepciones globales:** En Laravel 12, los handlers de excepción deben registrarse en `bootstrap/app.php` (`withExceptions`), no en `App\Exceptions\Handler::register()`. Se agregaron `\LogicException → 422` e `\InvalidArgumentException → 404`.
+- **Transacciones:** Las validaciones de negocio (`LogicException`, `InvalidArgumentException`) se ejecutan **fuera** del `DB::transaction()` para que el `ExceptionHandler` las capture directamente.
+- **Audit log:** Cada aprobación/rechazo individual queda registrada en el log de auditoría con la nomenclatura del hijo y del padre.

--- a/routes/api.php
+++ b/routes/api.php
@@ -378,6 +378,9 @@ Route::middleware(['auth:sanctum', 'refresh.session', 'throttle:60,1'])->group(f
     Route::get('aprobaciones-elementos/{aprobacionId}', [ElementApprovalController::class, 'showApproval']);
     Route::post('elementos/{elementoId}/aprobar', [ElementApprovalController::class, 'approveElemento'])->middleware('throttle:10,1');
     Route::post('elementos/{elementoId}/rechazar', [ElementApprovalController::class, 'rejectElemento'])->middleware('throttle:10,1');
+    // Aprobación individual de hijos dentro de un bloque de elemento
+    Route::post('elementos/{padreId}/hijos/{hijoId}/aprobar', [ElementApprovalController::class, 'approveIndividualChild'])->middleware('throttle:10,1');
+    Route::post('elementos/{padreId}/hijos/{hijoId}/rechazar', [ElementApprovalController::class, 'rejectIndividualChild'])->middleware('throttle:10,1');
 });
 
 // ============================================


### PR DESCRIPTION
- Migraciones 059/060/061: estados pendiente/incompleto y nueva_fecha_limite en APROBACION_ELEMENTO
- ElementApprovalService: approveIndividualChild, rejectIndividualChild, recalculateParentState
- Regla de bloqueo: hijo aprobado no modificable cuando padre esta incompleto (LogicException 422)
- ElementAssignmentObserver: reset automatico incompleto -> pendiente al completar asignacion rechazada
- ElementApprovalController: thin controller para los 2 nuevos endpoints
- Routes: POST elementos/{padreId}/hijos/{hijoId}/aprobar|rechazar (throttle 10/1)
- bootstrap/app.php: handlers globales LogicException->422 e InvalidArgumentException->404
- Docs: HU010_APROBACION_MODELO_FLEXIBLE.md con endpoints, flujo y notas tecnicas