### PR TITLE
feat_ HU-010: Notificaciones internas para aprobación/rechazo de elementos

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -36,6 +36,9 @@ class Notification extends Model
     public const TIPO_RECHAZO_CRITERIO    = 'rechazo_criterio';
     public const TIPO_APROBACION_EVIDENCIA = 'aprobacion_evidencia';
     public const TIPO_RECHAZO_EVIDENCIA = 'rechazo_evidencia';
+    // Agregados para HU-018 de notificaciones más específicas
+    public const TIPO_APROBACION_ELEMENTO  = 'aprobacion_elemento';
+    public const TIPO_RECHAZO_ELEMENTO     = 'rechazo_elemento';
     public const TIPO_SOLICITUD_AMPLIACION = 'solicitud_ampliacion';
     public const TIPO_RESPUESTA_AMPLIACION = 'respuesta_ampliacion';
     public const TIPO_COMENTARIO_NUEVO = 'comentario_nuevo';

--- a/app/Services/ElementApprovalService.php
+++ b/app/Services/ElementApprovalService.php
@@ -5,9 +5,11 @@ namespace App\Services;
 use App\Models\ElementApproval;
 use App\Models\ElementAssignment;
 use App\Models\StructureElement;
+use App\Models\Notification;
 use App\Events\ElementApproved;
 use App\Events\ElementRejected;
 use App\Services\AuditLogService;
+use App\Services\NotificationService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 
@@ -201,6 +203,38 @@ class ElementApprovalService
             'Aprobación Elements'
         );
 
+        // NUEVO (HU-notificaciones): por cada elemento aprobado (pauta + sus fuentes),
+        // busca quién tiene asignado ese elemento y le manda notificación interna (solo app).
+        // Va fuera de la transacción: si falla el envío no revierte la aprobación.
+        foreach ($allIds as $elementId) {
+            try {
+                $assignedUserIds = ElementAssignment::where('elemento_id', $elementId)
+                    ->where('proceso_id', $procesoId)
+                    ->pluck('usuario_id')
+                    ->unique()
+                    ->values()
+                    ->toArray();
+
+                if (!empty($assignedUserIds)) {
+                    $el = StructureElement::find($elementId);
+                    NotificationService::createMany(
+                        $assignedUserIds,
+                        [
+                            'tipo_evento' => Notification::TIPO_APROBACION_ELEMENTO,
+                            'titulo'      => "Elemento {$el->nomenclatura} aprobado",
+                            'mensaje'     => "El elemento {$el->nomenclatura} — {$el->descripcion} ha sido aprobado para el proceso #{$procesoId}.",
+                            'enlace'      => "/elementos/{$elementoId}/aprobaciones",
+                        ]
+                    );
+                }
+            } catch (\Throwable $excepcion) {
+                logger()->error('ElementApproved notification failed', [
+                    'elemento_id' => $elementId,
+                    'error'       => $excepcion->getMessage(),
+                ]);
+            }
+        }
+
         return $result;
     }
 
@@ -270,6 +304,41 @@ class ElementApprovalService
             'Aprobación Elements'
         );
 
+        // NUEVO (HU-notificaciones): por cada elemento rechazado (pauta + sus fuentes),
+        // busca quién tiene asignado ese elemento y le manda email + notificación interna.
+        // Incluye el comentario del evaluador y la nueva fecha límite si se proporcionaron.
+        $deadlineMessage = $fechaLimite ? " Nueva fecha límite: {$fechaLimite}." : '';
+        $reviewerComment = $comentario ? " Observación del evaluador: {$comentario}." : '';
+
+        foreach ($allIds as $elementId) {
+            try {
+                $assignedUserIds = ElementAssignment::where('elemento_id', $elementId)
+                    ->where('proceso_id', $procesoId)
+                    ->pluck('usuario_id')
+                    ->unique()
+                    ->values()
+                    ->toArray();
+
+                if (!empty($assignedUserIds)) {
+                    $el = StructureElement::find($elementId);
+                    NotificationService::createMany(
+                        $assignedUserIds,
+                        [
+                            'tipo_evento' => Notification::TIPO_RECHAZO_ELEMENTO,
+                            'titulo'      => "Elemento {$el->nomenclatura} rechazado — se requieren correcciones",
+                            'mensaje'     => "El elemento {$el->nomenclatura} — {$el->descripcion} ha sido rechazado para el proceso #{$procesoId}.{$reviewerComment}{$deadlineMessage} Por favor revisa y reenvía.",
+                            'enlace'      => "/elementos/{$elementoId}/aprobaciones",
+                        ]
+                    );
+                }
+            } catch (\Throwable $excepcion) {
+                logger()->error('ElementRejected notification failed', [
+                    'elemento_id' => $elementId,
+                    'error'       => $excepcion->getMessage(),
+                ]);
+            }
+        }
+
         return $result;
     }
 
@@ -319,7 +388,7 @@ class ElementApprovalService
             );
         }
 
-        return DB::transaction(function () use ($padreId, $hijoId, $procesoId, $hijo) {
+        $result = DB::transaction(function () use ($padreId, $hijoId, $procesoId, $hijo) {
             $usuarioId = Auth::id();
 
             $parentApproval = ElementApproval::firstOrCreate(
@@ -350,6 +419,37 @@ class ElementApprovalService
                 'hijo_approval'  => $childApproval->load(['elemento']),
             ];
         });
+
+        // NUEVO (HU-notificaciones): notifica al usuario asignado al hijo aprobado.
+        // Solo canal interno (app), no email — aprobación no requiere acción urgente.
+        try {
+            $assignedUserIds = ElementAssignment::where('elemento_id', $hijoId)
+                ->where('proceso_id', $procesoId)
+                ->pluck('usuario_id')
+                ->unique()
+                ->values()
+                ->toArray();
+
+            if (!empty($assignedUserIds)) {
+                $hijoEl = $result['hijo_approval']->elemento;
+                NotificationService::createMany(
+                    $assignedUserIds,
+                    [
+                        'tipo_evento' => Notification::TIPO_APROBACION_ELEMENTO,
+                        'titulo'      => "Elemento {$hijoEl->nomenclatura} aprobado",
+                        'mensaje'     => "El elemento {$hijoEl->nomenclatura} — {$hijoEl->descripcion} ha sido aprobado para el proceso #{$procesoId}.",
+                        'enlace'      => "/elementos/{$padreId}/aprobaciones",
+                    ]
+                );
+            }
+        } catch (\Throwable $excepcion) {
+            logger()->error('ChildElementApproved notification failed', [
+                'elemento_id' => $hijoId,
+                'error'       => $excepcion->getMessage(),
+            ]);
+        }
+
+        return $result;
     }
 
     /**
@@ -400,7 +500,7 @@ class ElementApprovalService
             );
         }
 
-        return DB::transaction(function () use ($padreId, $hijoId, $procesoId, $comentario, $nuevaFechaLimite, $hijo) {
+        $result = DB::transaction(function () use ($padreId, $hijoId, $procesoId, $comentario, $nuevaFechaLimite, $hijo) {
             $usuarioId = Auth::id();
 
             $parentApproval = ElementApproval::firstOrCreate(
@@ -445,5 +545,38 @@ class ElementApprovalService
                 'hijo_approval'  => $childApproval->load(['elemento']),
             ];
         });
+
+        // NUEVO (HU-notificaciones): notifica al usuario asignado al hijo rechazado.
+        // Canal email + app — rechazo individual requiere que el profesor corrija y reenvíe.
+        try {
+            $assignedUserIds = ElementAssignment::where('elemento_id', $hijoId)
+                ->where('proceso_id', $procesoId)
+                ->pluck('usuario_id')
+                ->unique()
+                ->values()
+                ->toArray();
+
+            if (!empty($assignedUserIds)) {
+                $hijoEl = $result['hijo_approval']->elemento;
+                $deadlineMessage = $nuevaFechaLimite ? " Nueva fecha límite: {$nuevaFechaLimite}." : '';
+                $reviewerComment = $comentario ? " Observación del evaluador: {$comentario}." : '';
+                NotificationService::createMany(
+                    $assignedUserIds,
+                    [
+                        'tipo_evento' => Notification::TIPO_RECHAZO_ELEMENTO,
+                        'titulo'      => "Elemento {$hijoEl->nomenclatura} rechazado — se requieren correcciones",
+                        'mensaje'     => "El elemento {$hijoEl->nomenclatura} — {$hijoEl->descripcion} ha sido rechazado para el proceso #{$procesoId}.{$reviewerComment}{$deadlineMessage} Por favor revisa y reenvía.",
+                        'enlace'      => "/elementos/{$padreId}/aprobaciones",
+                    ]
+                );
+            }
+        } catch (\Throwable $excepcion) {
+            logger()->error('ChildElementRejected notification failed', [
+                'elemento_id' => $hijoId,
+                'error'       => $excepcion->getMessage(),
+            ]);
+        }
+
+        return $result;
     }
 }

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -235,6 +235,7 @@ class NotificationService
             Notification::TIPO_SOLICITUD_AMPLIACION,
             Notification::TIPO_RECHAZO_CRITERIO,
             Notification::TIPO_RECHAZO_EVIDENCIA,
+            Notification::TIPO_RECHAZO_ELEMENTO,
         ];
 
         if (in_array($tipoEvento, $eventosCriticos) || $forzarEmail) {

--- a/database/factories/ElementApprovalFactory.php
+++ b/database/factories/ElementApprovalFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ElementApproval;
+use App\Models\Process;
+use App\Models\StructureElement;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ElementApprovalFactory extends Factory
+{
+    protected $model = ElementApproval::class;
+
+    public function definition(): array
+    {
+        return [
+            'elemento_id'       => StructureElement::factory(),
+            'proceso_id'        => Process::factory(),
+            'usuario_id'        => User::factory(),
+            'estado'            => 'aprobado',
+            'comentario'        => $this->faker->optional()->sentence(),
+            'nueva_fecha_limite'=> null,
+        ];
+    }
+
+    public function rechazado(): static
+    {
+        return $this->state(fn () => [
+            'estado'            => 'rechazado',
+            'nueva_fecha_limite'=> now()->addDays(30)->toDateString(),
+        ]);
+    }
+
+    public function pendiente(): static
+    {
+        return $this->state(fn () => [
+            'estado' => 'pendiente',
+        ]);
+    }
+}

--- a/database/migrations/2026_04_05_142059_add_elemento_approval_types_to_notificacion_tipo_evento.php
+++ b/database/migrations/2026_04_05_142059_add_elemento_approval_types_to_notificacion_tipo_evento.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE NOTIFICACION MODIFY COLUMN tipo_evento ENUM(
+            'asignacion_evidencia',
+            'asignacion_elemento',
+            'carga_archivo',
+            'vencimiento_plazo',
+            'devolucion_observacion',
+            'aprobacion_criterio',
+            'rechazo_criterio',
+            'aprobacion_evidencia',
+            'rechazo_evidencia',
+            'aprobacion_elemento',
+            'rechazo_elemento',
+            'solicitud_ampliacion',
+            'respuesta_ampliacion',
+            'comentario_nuevo',
+            'actualizacion_sistema'
+        ) NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE NOTIFICACION MODIFY COLUMN tipo_evento ENUM(
+            'asignacion_evidencia',
+            'asignacion_elemento',
+            'carga_archivo',
+            'vencimiento_plazo',
+            'devolucion_observacion',
+            'aprobacion_criterio',
+            'aprobacion_evidencia',
+            'rechazo_evidencia',
+            'solicitud_ampliacion',
+            'respuesta_ampliacion',
+            'comentario_nuevo',
+            'actualizacion_sistema'
+        ) NOT NULL");
+    }
+};

--- a/docs/HU_NOTIFICACIONES_MODELO_FLEXIBLE.md
+++ b/docs/HU_NOTIFICACIONES_MODELO_FLEXIBLE.md
@@ -1,0 +1,158 @@
+# Notificaciones — Modelo Flexible (ElementApprovalService)
+
+## Qué se hizo
+
+Se agregaron notificaciones automáticas al `ElementApprovalService`, equivalentes a lo que Naydelin implementó en `CriterionApprovalService` para el modelo tradicional.
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `app/Models/Notification.php` | +2 constantes: `TIPO_APROBACION_ELEMENTO`, `TIPO_RECHAZO_ELEMENTO` |
+| `app/Services/NotificationService.php` | `TIPO_RECHAZO_ELEMENTO` agregado a eventos críticos → canal email+app |
+| `app/Services/ElementApprovalService.php` | +imports de `Notification` y `NotificationService`, +4 bloques de notificación |
+| `database/migrations/2026_04_05_142059_add_elemento_approval_types_to_notificacion_tipo_evento.php` | Migración que agrega los nuevos valores al ENUM `tipo_evento` de la tabla `NOTIFICACION` en MySQL |
+
+### Por qué fue necesaria la migración
+
+La columna `tipo_evento` en la tabla `NOTIFICACION` es de tipo **ENUM** en MySQL — solo acepta valores predefinidos. Sin esta migración, al intentar insertar `rechazo_elemento` MySQL lo rechazaba con error *"Data truncated"*.
+
+Los valores agregados al ENUM:
+- `rechazo_criterio` (lo había creado Naydelin en el modelo PHP pero faltaba en la BD)
+- `aprobacion_elemento` ← nuevo
+- `rechazo_elemento` ← nuevo
+
+### Reglas de canal
+
+| Tipo | Canal |
+|---|---|
+| `TIPO_APROBACION_ELEMENTO` | Solo app (buena noticia, no urgente) |
+| `TIPO_RECHAZO_ELEMENTO` | Email + app (requiere acción del profesor) |
+
+### Los 4 métodos con notificaciones nuevas
+
+| Método | Qué hace | A quién notifica |
+|---|---|---|
+| `approveElemento(padreId)` | Aprueba pauta + todas sus fuentes en cascada | A cada usuario asignado a cada elemento aprobado |
+| `rejectElemento(padreId)` | Rechaza pauta + todas sus fuentes en cascada | A cada usuario asignado, con comentario + nueva fecha |
+| `approveIndividualChild(padreId, hijoId)` | Aprueba una fuente individual | Al usuario asignado a esa fuente |
+| `rejectIndividualChild(padreId, hijoId)` | Rechaza una fuente individual | Al usuario asignado, con comentario + nueva fecha |
+
+> Las notificaciones van **fuera de la transacción DB** — si falla el envío del correo, la aprobación/rechazo NO se revierte.
+
+---
+
+## Cómo probar en Postman
+
+### Datos reales de la BD (para las pruebas)
+
+- `proceso_id`: **33**
+- `elemento padre`: **19** (AG-01 — Area de Gestion Academica)
+- `elemento hijo`: **20** (AG-01.1 — Componente de planificacion curricular)
+- `usuario asignado`: **56** y **57**
+
+### Paso 1 — Autenticarse
+
+```
+POST http://localhost:8000/api/auth/login
+Content-Type: application/json
+
+{
+  "username": "<usuario_coordinador_o_evaluador>",
+  "password": "<password>"
+}
+```
+
+Copiar el `token` de la respuesta y usarlo como `Bearer Token` en los siguientes requests.
+
+---
+
+### Prueba 1 — Aprobar bloque completo (pauta + hijos en cascada)
+
+```
+POST http://localhost:8000/api/elementos/19/aprobar
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "proceso_id": 33,
+  "comentario": "Todo correcto"
+}
+```
+
+**Resultado esperado:**
+- Status `200`
+- En tabla `NOTIFICACION`: registro con `tipo_evento = 'aprobacion_elemento'` para usuarios 56 y 57
+- Canal: solo interno (app)
+
+---
+
+### Prueba 2 — Rechazar bloque completo (con fecha y comentario)
+
+```
+POST http://localhost:8000/api/elementos/19/rechazar
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "proceso_id": 33,
+  "comentario": "Falta documentación de respaldo",
+  "fecha_limite": "2026-05-15"
+}
+```
+
+**Resultado esperado:**
+- Status `200`
+- En tabla `NOTIFICACION`: registro con `tipo_evento = 'rechazo_elemento'` para usuarios 56 y 57
+- Canal: `ambos` (email + app)
+- El mensaje incluye el comentario y la nueva fecha
+
+---
+
+### Prueba 3 — Aprobar un hijo individual
+
+```
+POST http://localhost:8000/api/elementos/19/hijos/20/aprobar
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "proceso_id": 33
+}
+```
+
+**Resultado esperado:**
+- Status `200`
+- Notificación interna (solo app) al usuario asignado al elemento 20
+
+---
+
+### Prueba 4 — Rechazar un hijo individual
+
+```
+POST http://localhost:8000/api/elementos/19/hijos/20/rechazar
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "proceso_id": 33,
+  "comentario": "El componente no cumple los criterios mínimos",
+  "nueva_fecha_limite": "2026-05-20"
+}
+```
+
+**Resultado esperado:**
+- Status `200`
+- Notificación por email + app al usuario asignado al elemento 20
+- Mensaje con comentario y nueva fecha
+
+---
+
+### Verificar en BD después de cada prueba
+
+```sql
+SELECT notificacion_id, usuario_id, tipo_evento, canal, titulo, mensaje, created_at
+FROM NOTIFICACION
+ORDER BY created_at DESC
+LIMIT 5;
+```

--- a/tests/Feature/AccreditationCycleFeatureTest.php
+++ b/tests/Feature/AccreditationCycleFeatureTest.php
@@ -1,14 +1,361 @@
 <?php
 
+namespace Tests\Feature;
+
 use App\Models\AccreditationCycle;
+use App\Models\CareerCampus;
+use App\Models\StructureModel;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
 
-it('can create and retrieve an accreditation cycle', function () {
-    $cycle = AccreditationCycle::factory()->create([
-        'nombre' => 'Ciclo 2026',
-    ]);
+class AccreditationCycleFeatureTest extends TestCase
+{
+    use RefreshDatabase;
 
-    $found = AccreditationCycle::where('nombre', 'Ciclo 2026')->first();
-    expect($found)->not->toBeNull();
-    expect($found->nombre)->toBe('Ciclo 2026');
-});
+    private string $baseEndpoint = '/api/estructura/ciclos-acreditacion';
+    private User $superusuario;
+    private CareerCampus $careerCampus;
+    private StructureModel $modelo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+        // Usuario con todos los permisos de ciclos
+        $this->superusuario = User::factory()->create();
+        $this->superusuario->assignRole(Role::where('name', 'Superusuario')->first());
+
+        // Datos base reutilizables
+        $this->careerCampus = CareerCampus::factory()->create();
+        $this->modelo       = StructureModel::factory()->create();
+    }
+
+    // ─── Helper ──────────────────────────────────────────────────────────────
+
+    private function cicloPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo Test ' . uniqid(),
+            'estado'               => 'activo',
+        ], $overrides);
+    }
+
+    // ─── AC-5: Autenticación ─────────────────────────────────────────────────
+
+    public function test_retorna_401_sin_token_en_get_index(): void
+    {
+        $this->getJson($this->baseEndpoint)->assertStatus(401);
+    }
+
+    public function test_retorna_403_a_usuario_sin_permiso_ciclos_view(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole(Role::where('name', 'Profesor')->first());
+        Sanctum::actingAs($user);
+
+        $this->getJson($this->baseEndpoint)->assertStatus(403);
+    }
+
+    // ─── AC-1 y AC-3: Crear y listar ciclos ──────────────────────────────────
+
+    public function test_post_crea_ciclo_valido_y_retorna_201_AC1(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $response = $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo 2026-2030',
+        ])->assertStatus(201);
+
+        $response->assertJsonPath('data.nombre', 'Ciclo 2026-2030');
+        $response->assertJsonPath('data.estado', 'activo');
+
+        $this->assertDatabaseHas('CICLO_ACREDITACION', [
+            'nombre'          => 'Ciclo 2026-2030',
+            'carrera_sede_id' => $this->careerCampus->carrera_sede_id,
+        ]);
+    }
+
+    public function test_get_index_retorna_ciclos_paginados_con_estructura_meta_AC3(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        AccreditationCycle::factory()->count(3)->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+        ]);
+
+        $response = $this->getJson($this->baseEndpoint)->assertStatus(200);
+
+        $response->assertJsonStructure(['data', 'meta']);
+        $this->assertGreaterThanOrEqual(3, count($response->json('data')));
+    }
+
+    public function test_get_show_retorna_un_ciclo_existente_AC1(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo Show Test',
+        ]);
+
+        $this->getJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}")
+             ->assertStatus(200)
+             ->assertJsonPath('data.nombre', 'Ciclo Show Test');
+    }
+
+    public function test_get_show_retorna_404_si_el_ciclo_no_existe(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->getJson("{$this->baseEndpoint}/999999")->assertStatus(404);
+    }
+
+    // ─── AC-2: Validaciones de entrada ───────────────────────────────────────
+
+    public function test_post_retorna_422_sin_nombre_AC2(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+        ])->assertStatus(422)->assertJsonValidationErrors(['nombre']);
+    }
+
+    public function test_post_retorna_422_sin_carrera_sede_id_AC2(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson($this->baseEndpoint, [
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo sin sede',
+        ])->assertStatus(422)->assertJsonValidationErrors(['carrera_sede_id']);
+    }
+
+    public function test_post_retorna_422_sin_modelo_estructura_id_AC2(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id' => $this->careerCampus->carrera_sede_id,
+            'nombre'          => 'Ciclo sin modelo',
+        ])->assertStatus(422)->assertJsonValidationErrors(['modelo_estructura_id']);
+    }
+
+    public function test_post_retorna_422_con_estado_invalido_AC2(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo estado invalido',
+            'estado'               => 'eliminado',
+        ])->assertStatus(422)->assertJsonValidationErrors(['estado']);
+    }
+
+    // ─── AC-6: Máximo un ciclo activo por carrera+sede ───────────────────────
+
+    public function test_post_retorna_422_cuando_ya_existe_ciclo_activo_en_misma_sede_AC6(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'activo',
+        ]);
+
+        $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Segundo ciclo activo',
+            'estado'               => 'activo',
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['carrera_sede_id']);
+    }
+
+    public function test_post_permite_ciclo_activo_en_sede_diferente_AC6(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'activo',
+        ]);
+
+        $otraCareerCampus = CareerCampus::factory()->create();
+
+        $this->postJson($this->baseEndpoint, [
+            'carrera_sede_id'      => $otraCareerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Ciclo otra sede',
+            'estado'               => 'activo',
+        ])->assertStatus(201);
+    }
+
+    // ─── AC-4: Edición bloqueada si no está activo ───────────────────────────
+
+    public function test_patch_actualiza_ciclo_activo_exitosamente_AC4(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'nombre'               => 'Nombre Original',
+            'estado'               => 'activo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}", [
+            'nombre' => 'Nombre Actualizado',
+        ])->assertStatus(200)
+          ->assertJsonPath('data.nombre', 'Nombre Actualizado');
+    }
+
+    public function test_patch_retorna_403_al_editar_ciclo_inactivo_AC4(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}", [
+            'nombre' => 'Intento de edicion',
+        ])->assertStatus(403);
+    }
+
+    public function test_patch_retorna_403_al_editar_ciclo_completado_AC4(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'completado',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}", [
+            'nombre' => 'Intento de edicion',
+        ])->assertStatus(403);
+    }
+
+    public function test_patch_sin_campos_retorna_422_AC2(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'activo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}", [])
+             ->assertStatus(422);
+    }
+
+    // ─── AC-5: DELETE requiere permiso ciclos.delete ─────────────────────────
+
+    public function test_delete_retorna_403_a_usuario_sin_permiso_ciclos_delete_AC5(): void
+    {
+        $profesor = User::factory()->create();
+        $profesor->assignRole(Role::where('name', 'Profesor')->first());
+        Sanctum::actingAs($profesor);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+        ]);
+
+        $this->deleteJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}")
+             ->assertStatus(403);
+    }
+
+    // ─── AC-R: Reactivación de ciclos (solo Superusuario) ────────────────────
+
+    public function test_patch_reactivar_cambia_ciclo_inactivo_a_activo_ACR(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}/reactivar")
+             ->assertStatus(200)
+             ->assertJsonPath('data.estado', 'activo');
+
+        $this->assertDatabaseHas('CICLO_ACREDITACION', [
+            'ciclo_acreditacion_id' => $ciclo->ciclo_acreditacion_id,
+            'estado'                => 'activo',
+        ]);
+    }
+
+    public function test_patch_reactivar_retorna_422_si_ciclo_ya_esta_activo_ACR(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'activo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}/reactivar")
+             ->assertStatus(422);
+    }
+
+    public function test_patch_reactivar_retorna_403_para_usuario_Administrador_ACR(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole(Role::where('name', 'Administrador')->first());
+        Sanctum::actingAs($admin);
+
+        $ciclo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$ciclo->ciclo_acreditacion_id}/reactivar")
+             ->assertStatus(403);
+    }
+
+    public function test_patch_reactivar_retorna_422_cuando_ya_hay_otro_ciclo_activo_en_misma_sede_ACR_AC6(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'activo',
+        ]);
+
+        $cicloInactivo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $this->careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $this->modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+
+        $this->patchJson("{$this->baseEndpoint}/{$cicloInactivo->ciclo_acreditacion_id}/reactivar")
+             ->assertStatus(422);
+    }
+}
 

--- a/tests/Feature/ElementApprovalFeatureTest.php
+++ b/tests/Feature/ElementApprovalFeatureTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AccreditationCycle;
+use App\Models\CareerCampus;
+use App\Models\ElementApproval;
+use App\Models\Process;
+use App\Models\Role;
+use App\Models\StructureElement;
+use App\Models\StructureModel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * Tests de Feature para HU-010: Aprobación de Elementos (modelo flexible).
+ * Rutas: /api/aprobaciones-elementos, /api/elementos/{id}/aprobar, /api/elementos/{id}/rechazar
+ */
+class ElementApprovalFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $superusuario;
+    private Process $proceso;
+    private StructureElement $elemento;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+        // Superusuario tiene todos los permisos (aprobaciones.approve, aprobaciones.reject, aprobaciones.view)
+        $this->superusuario = User::factory()->create();
+        $this->superusuario->assignRole(Role::where('name', 'Superusuario')->first());
+
+        // Estructura mínima: modelo → ciclo → proceso + elemento del mismo modelo
+        $modelo             = StructureModel::factory()->create();
+        $careerCampus       = CareerCampus::factory()->create();
+        $ciclo              = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+        ]);
+        $this->proceso  = Process::factory()->create([
+            'ciclo_acreditacion_id' => $ciclo->ciclo_acreditacion_id,
+        ]);
+        $this->elemento = StructureElement::factory()->create([
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+            'padre_id'             => null,
+        ]);
+    }
+
+    // ─── Helper ──────────────────────────────────────────────────────────────
+
+    private function aprobarPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'proceso_id' => $this->proceso->proceso_id,
+            'comentario' => 'Elemento revisado correctamente.',
+        ], $overrides);
+    }
+
+    // ─── Control de acceso ───────────────────────────────────────────────────
+
+    public function test_retorna_401_sin_token_en_aprobar(): void
+    {
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(401);
+    }
+
+    public function test_retorna_401_sin_token_en_rechazar(): void
+    {
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", $this->aprobarPayload())
+             ->assertStatus(401);
+    }
+
+    public function test_retorna_401_sin_token_en_listApprovals(): void
+    {
+        $this->getJson('/api/aprobaciones-elementos')->assertStatus(401);
+    }
+
+    public function test_retorna_403_a_Profesor_en_aprobar(): void
+    {
+        $profesor = User::factory()->create();
+        $profesor->assignRole(Role::where('name', 'Profesor')->first());
+        Sanctum::actingAs($profesor);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(403);
+    }
+
+    public function test_retorna_403_a_Profesor_en_rechazar(): void
+    {
+        $profesor = User::factory()->create();
+        $profesor->assignRole(Role::where('name', 'Profesor')->first());
+        Sanctum::actingAs($profesor);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", $this->aprobarPayload())
+             ->assertStatus(403);
+    }
+
+    // ─── Validación de entrada ────────────────────────────────────────────────
+
+    public function test_aprobar_retorna_422_sin_proceso_id(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", [])
+             ->assertStatus(422)
+             ->assertJsonValidationErrors(['proceso_id']);
+    }
+
+    public function test_rechazar_retorna_422_sin_proceso_id(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", [])
+             ->assertStatus(422)
+             ->assertJsonValidationErrors(['proceso_id']);
+    }
+
+    public function test_aprobar_retorna_422_con_proceso_id_inexistente(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", [
+            'proceso_id' => 999999,
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['proceso_id']);
+    }
+
+    public function test_aprobar_retorna_422_cuando_elemento_no_existe(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/999999/aprobar", $this->aprobarPayload())
+             ->assertStatus(422);
+    }
+
+    public function test_rechazar_retorna_422_cuando_elemento_no_existe(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/999999/rechazar", $this->aprobarPayload())
+             ->assertStatus(422);
+    }
+
+    public function test_aprobar_retorna_422_cuando_comentario_supera_100_caracteres(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", [
+            'proceso_id' => $this->proceso->proceso_id,
+            'comentario' => str_repeat('A', 101),
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['comentario']);
+    }
+
+    // ─── Flujo feliz: aprobar ─────────────────────────────────────────────────
+
+    public function test_superusuario_aprueba_elemento_y_retorna_201(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $response = $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(201);
+
+        $response->assertJsonPath('data.raiz.estado', 'aprobado');
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'estado'      => 'aprobado',
+        ]);
+    }
+
+    public function test_aprobar_dos_veces_retorna_422(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        // Primera aprobación
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(201);
+
+        // Segunda aprobación debe fallar
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(422);
+    }
+
+    // ─── Flujo feliz: rechazar ────────────────────────────────────────────────
+
+    public function test_superusuario_rechaza_elemento_y_retorna_201(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $response = $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", $this->aprobarPayload())
+             ->assertStatus(201);
+
+        $response->assertJsonPath('data.raiz.estado', 'rechazado');
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'estado'      => 'rechazado',
+        ]);
+    }
+
+    public function test_rechazar_dos_veces_retorna_422(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", $this->aprobarPayload())
+             ->assertStatus(201);
+
+        $this->postJson("/api/elementos/{$this->elemento->elemento_id}/rechazar", $this->aprobarPayload())
+             ->assertStatus(422);
+    }
+
+    // ─── Listado y detalle ────────────────────────────────────────────────────
+
+    public function test_GET_listApprovals_retorna_200_con_data(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        // Crear una aprobación existente
+        ElementApproval::factory()->create([
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->superusuario->usuario_id,
+            'estado'      => 'aprobado',
+        ]);
+
+        $response = $this->getJson('/api/aprobaciones-elementos')->assertStatus(200);
+
+        $this->assertTrue($response->json('success'));
+        $this->assertIsArray($response->json('data'));
+    }
+
+    public function test_GET_showApproval_retorna_200_para_aprobacion_existente(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $aprobacion = ElementApproval::factory()->create([
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->superusuario->usuario_id,
+            'estado'      => 'aprobado',
+        ]);
+
+        $this->getJson("/api/aprobaciones-elementos/{$aprobacion->aprobacion_elemento_id}")
+             ->assertStatus(200)
+             ->assertJsonPath('success', true);
+    }
+
+    public function test_GET_showApproval_retorna_404_si_no_existe(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $this->getJson('/api/aprobaciones-elementos/999999')
+             ->assertStatus(404);
+    }
+
+    // ─── Cascada sobre hijos ─────────────────────────────────────────────────
+
+    public function test_aprobar_elemento_padre_aprueba_hijos_en_cascada(): void
+    {
+        Sanctum::actingAs($this->superusuario);
+
+        $modelo = $this->elemento->modelo_estructura_id;
+
+        // Crear dos hijos activos del elemento raíz
+        $hijo1 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $modelo,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+        $hijo2 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $modelo,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+
+        $response = $this->postJson("/api/elementos/{$this->elemento->elemento_id}/aprobar", $this->aprobarPayload())
+             ->assertStatus(201);
+
+        // El raíz está aprobado
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+
+        // Los hijos también se aprobaron en cascada
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $hijo1->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $hijo2->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+
+        // La respuesta indica la cascada
+        $this->assertCount(2, $response->json('data.cascada'));
+    }
+}

--- a/tests/Feature/RetroalimentacionFeatureTest.php
+++ b/tests/Feature/RetroalimentacionFeatureTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Role;
+use App\Models\Evidence;
+use App\Models\Criterion;
+use App\Models\Component;
+use App\Models\Dimension;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class RetroalimentacionFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $baseEndpoint = '/api/estructura/evidencias';
+    private User $encargado;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+        // Encargado autorizado: necesita evidencias.edit para pasar el middleware de la ruta
+        $this->encargado = User::factory()->create();
+        $this->encargado->assignRole(Role::where('name', 'Encargado de Acreditación')->first());
+        $this->encargado->givePermissionTo(
+            Permission::findByName('evidencias.edit', 'api')
+        );
+    }
+
+    // ─── Helper: crea evidencia en un estado revisable ───────────────────────
+
+    private function crearEvidenciaRevisable(string $estado = 'En Proceso'): Evidence
+    {
+        $dimension = Dimension::factory()->create();
+        $component = Component::factory()->create(['dimension_id' => $dimension->getKey()]);
+        $criterion = Criterion::factory()->create(['componente_id' => $component->getKey()]);
+
+        return Evidence::factory()->create([
+            'criterio_id' => $criterion->getKey(),
+            'estado'      => $estado,
+        ]);
+    }
+
+    // ─── AC-5: Control de acceso ─────────────────────────────────────────────
+
+    public function test_retorna_401_si_no_hay_token_de_autenticacion(): void
+    {
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Comentario de prueba válido.',
+        ])->assertStatus(401);
+    }
+
+    public function test_retorna_403_si_el_usuario_tiene_rol_Profesor(): void
+    {
+        $profesor = User::factory()->create();
+        $profesor->assignRole(Role::where('name', 'Profesor')->first());
+        Sanctum::actingAs($profesor);
+
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Intento no autorizado.',
+        ])->assertStatus(403);
+    }
+
+    // ─── 404 ─────────────────────────────────────────────────────────────────
+
+    public function test_retorna_404_cuando_la_evidencia_no_existe(): void
+    {
+        Sanctum::actingAs($this->encargado);
+
+        $this->postJson("{$this->baseEndpoint}/999999/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Comentario para evidencia inexistente.',
+        ])->assertStatus(404);
+    }
+
+    // ─── AC-2: Validación de campos ──────────────────────────────────────────
+
+    public function test_retorna_422_cuando_el_comentario_esta_vacio(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => '',
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['comentario']);
+    }
+
+    public function test_retorna_422_cuando_el_comentario_tiene_menos_de_5_caracteres(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Hi',
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['comentario']);
+    }
+
+    public function test_retorna_422_cuando_el_comentario_supera_los_800_caracteres(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => str_repeat('A', 801),
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['comentario']);
+    }
+
+    public function test_retorna_422_cuando_el_estado_no_esta_entre_Observada_y_Validada(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable();
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Aprobado',
+            'comentario' => 'Estado que no debería aceptarse.',
+        ])->assertStatus(422)
+          ->assertJsonValidationErrors(['estado']);
+    }
+
+    public function test_retorna_422_cuando_la_evidencia_esta_en_estado_Pendiente(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable('Pendiente');
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'No se puede retroalimentar si está pendiente.',
+        ])->assertStatus(422);
+    }
+
+    // ─── Flujo feliz: 200 OK ─────────────────────────────────────────────────
+
+    public function test_encargado_puede_marcar_evidencia_como_Observada_y_guarda_comentario(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable('En Proceso');
+
+        $response = $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Falta la firma del director en el acta.',
+        ])->assertStatus(200);
+
+        $response->assertJsonPath('data.estado', 'Observada');
+
+        $this->assertDatabaseHas('EVIDENCIA', [
+            'evidencia_id' => $evidence->getKey(),
+            'estado'       => 'Observada',
+        ]);
+
+        $this->assertDatabaseHas('COMENTARIO', [
+            'texto'      => 'Falta la firma del director en el acta.',
+            'usuario_id' => $this->encargado->usuario_id,
+        ]);
+    }
+
+    public function test_encargado_puede_marcar_evidencia_como_Validada_y_guarda_comentario(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable('En Proceso');
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Validada',
+            'comentario' => 'Evidencia revisada y aprobada. Cumple todos los requisitos.',
+        ])->assertStatus(200)
+          ->assertJsonPath('data.estado', 'Validada');
+
+        $this->assertDatabaseHas('EVIDENCIA', [
+            'evidencia_id' => $evidence->getKey(),
+            'estado'       => 'Validada',
+        ]);
+    }
+
+    public function test_la_respuesta_incluye_el_comentario_recien_creado_en_el_array_de_comentarios(): void
+    {
+        Sanctum::actingAs($this->encargado);
+        $evidence = $this->crearEvidenciaRevisable('Completado');
+
+        $response = $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Se requiere adjuntar evidencia fotográfica.',
+        ])->assertStatus(200);
+
+        $comentarios = $response->json('data.comentarios');
+        $this->assertNotNull($comentarios);
+        $this->assertGreaterThanOrEqual(1, count($comentarios));
+
+        $textos = array_column($comentarios, 'texto');
+        $this->assertContains('Se requiere adjuntar evidencia fotográfica.', $textos);
+    }
+
+    public function test_administrador_tambien_puede_retroalimentar_evidencias(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole(Role::where('name', 'Superusuario')->first());
+        Sanctum::actingAs($super);
+
+        $evidence = $this->crearEvidenciaRevisable('Vencido');
+
+        $this->postJson("{$this->baseEndpoint}/{$evidence->getKey()}/retroalimentacion", [
+            'estado'     => 'Observada',
+            'comentario' => 'Evidencia vencida con observaciones.',
+        ])->assertStatus(200);
+    }
+}

--- a/tests/Unit/AccreditationCycleTest.php
+++ b/tests/Unit/AccreditationCycleTest.php
@@ -1,96 +1,181 @@
 <?php
 
+namespace Tests\Unit;
+
 use App\Models\AccreditationCycle;
+use App\Models\Career;
+use App\Models\Campus;
+use App\Models\CareerCampus;
+use App\Models\StructureModel;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
-it('creates an accreditation cycle', function () {
-    // Prueba de creación de ciclo de acreditación
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    $cycle = AccreditationCycle::factory()->create([
-        'nombre' => 'Ciclo 2025',
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-    $this->assertDatabaseHas('CICLO_ACREDITACION', [
-        'nombre' => 'Ciclo 2025',
-    ]);
-});
+class AccreditationCycleTest extends TestCase
+{
+    use RefreshDatabase;
 
-it('requires nombre field', function () {
-    // Prueba de validación: campo nombre es obligatorio
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    AccreditationCycle::factory()->create([
-        'nombre' => null,
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-})->throws(\Illuminate\Database\QueryException::class);
+    public function test_creates_an_accreditation_cycle(): void
+    {
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        AccreditationCycle::factory()->create([
+            'nombre'          => 'Ciclo 2025',
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
 
-it('updates an accreditation cycle', function () {
-    // Prueba de actualización de ciclo de acreditación
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    $cycle = AccreditationCycle::factory()->create([
-        'nombre' => 'Original',
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-    $cycle->update(['nombre' => 'Actualizado']);
-    $this->assertDatabaseHas('CICLO_ACREDITACION', ['nombre' => 'Actualizado']);
-});
+        $this->assertDatabaseHas('CICLO_ACREDITACION', [
+            'nombre' => 'Ciclo 2025',
+        ]);
+    }
 
-it('deletes an accreditation cycle', function () {
-    // Prueba de eliminación de ciclo de acreditación
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    $cycle = AccreditationCycle::factory()->create([
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-    $cycle->delete();
-    $this->assertDatabaseMissing('CICLO_ACREDITACION', ['ciclo_acreditacion_id' => $cycle->ciclo_acreditacion_id]);
-});
+    public function test_requires_nombre_field(): void
+    {
+        $this->expectException(QueryException::class);
 
-it('accreditation cycle belongs to career campus', function () {
-    // Prueba de relación belongsTo con CareerCampus
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    $cycle = AccreditationCycle::factory()->create([
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-    expect($cycle->careerCampus->carrera_sede_id)->toBe($careerCampus->carrera_sede_id);
-});
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        AccreditationCycle::factory()->create([
+            'nombre'          => null,
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
+    }
 
-it('accreditation cycle has many processes', function () {
-    // Prueba de relación hasMany con Process
-    $career = \App\Models\Career::factory()->create();
-    $campus = \App\Models\Campus::factory()->create();
-    $careerCampus = \App\Models\CareerCampus::factory()->create([
-        'carrera_id' => $career->carrera_id,
-        'sede_id' => $campus->sede_id,
-    ]);
-    $cycle = AccreditationCycle::factory()->create([
-        'carrera_sede_id' => $careerCampus->carrera_sede_id,
-    ]);
-    $process = \App\Models\Process::factory()->create([
-        'ciclo_acreditacion_id' => $cycle->ciclo_acreditacion_id,
-    ]);
-    expect($cycle->processes->contains($process))->toBeTrue();
-});
+    public function test_updates_an_accreditation_cycle(): void
+    {
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        $cycle = AccreditationCycle::factory()->create([
+            'nombre'          => 'Original',
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
+        $cycle->update(['nombre' => 'Actualizado']);
+
+        $this->assertDatabaseHas('CICLO_ACREDITACION', ['nombre' => 'Actualizado']);
+    }
+
+    public function test_deletes_an_accreditation_cycle(): void
+    {
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        $cycle = AccreditationCycle::factory()->create([
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
+        $cycle->delete();
+
+        $this->assertDatabaseMissing('CICLO_ACREDITACION', ['ciclo_acreditacion_id' => $cycle->ciclo_acreditacion_id]);
+    }
+
+    public function test_accreditation_cycle_belongs_to_career_campus(): void
+    {
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        $cycle = AccreditationCycle::factory()->create([
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
+
+        $this->assertSame($careerCampus->carrera_sede_id, $cycle->careerCampus->carrera_sede_id);
+    }
+
+    public function test_accreditation_cycle_has_many_processes(): void
+    {
+        $career = Career::factory()->create();
+        $campus = Campus::factory()->create();
+        $careerCampus = CareerCampus::factory()->create([
+            'carrera_id' => $career->carrera_id,
+            'sede_id'    => $campus->sede_id,
+        ]);
+        $cycle = AccreditationCycle::factory()->create([
+            'carrera_sede_id' => $careerCampus->carrera_sede_id,
+        ]);
+        $process = \App\Models\Process::factory()->create([
+            'ciclo_acreditacion_id' => $cycle->ciclo_acreditacion_id,
+        ]);
+
+        $this->assertTrue($cycle->processes->contains($process));
+    }
+
+    // ─── HU-030: helpers de estado ───────────────────────────────────────────
+
+    public function test_isActive_retorna_true_solo_cuando_estado_es_activo_AC4(): void
+    {
+        $careerCampus = CareerCampus::factory()->create();
+
+        $activo     = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'activo']);
+        $inactivo   = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'inactivo']);
+        $completado = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'completado']);
+
+        $this->assertTrue($activo->isActive());
+        $this->assertFalse($inactivo->isActive());
+        $this->assertFalse($completado->isActive());
+    }
+
+    public function test_isEditable_retorna_true_solo_para_ciclo_activo_AC4(): void
+    {
+        $careerCampus = CareerCampus::factory()->create();
+
+        $activo     = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'activo']);
+        $inactivo   = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'inactivo']);
+        $completado = AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'completado']);
+
+        $this->assertTrue($activo->isEditable());
+        $this->assertFalse($inactivo->isEditable());
+        $this->assertFalse($completado->isEditable());
+    }
+
+    public function test_scope_active_filtra_solo_ciclos_activos(): void
+    {
+        $careerCampus = CareerCampus::factory()->create();
+
+        AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'activo']);
+        AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'inactivo']);
+        AccreditationCycle::factory()->create(['carrera_sede_id' => $careerCampus->carrera_sede_id, 'estado' => 'completado']);
+
+        $activos = AccreditationCycle::where('carrera_sede_id', $careerCampus->carrera_sede_id)->active()->get();
+
+        $this->assertCount(1, $activos);
+        $this->assertSame('activo', $activos->first()->estado);
+    }
+
+    public function test_permite_crear_ciclo_inactivo_sin_restriccion_de_unicidad_activa(): void
+    {
+        $careerCampus = CareerCampus::factory()->create();
+        $modelo       = StructureModel::factory()->create();
+
+        AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+        $segundo = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+            'estado'               => 'inactivo',
+        ]);
+
+        $this->assertDatabaseHas('CICLO_ACREDITACION', [
+            'ciclo_acreditacion_id' => $segundo->ciclo_acreditacion_id,
+            'estado'                => 'inactivo',
+        ]);
+    }
+}

--- a/tests/Unit/ElementApprovalTest.php
+++ b/tests/Unit/ElementApprovalTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\AccreditationCycle;
+use App\Models\CareerCampus;
+use App\Models\ElementApproval;
+use App\Models\Process;
+use App\Models\StructureElement;
+use App\Models\StructureModel;
+use App\Models\User;
+use App\Services\ElementApprovalService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Tests unitarios para ElementApprovalService — HU-010 modelo flexible.
+ */
+class ElementApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ElementApprovalService $service;
+    private Process $proceso;
+    private StructureElement $elemento;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ElementApprovalService();
+
+        $this->user = User::factory()->create();
+        Sanctum::actingAs($this->user);
+
+        $modelo         = StructureModel::factory()->create();
+        $careerCampus   = CareerCampus::factory()->create();
+        $ciclo          = AccreditationCycle::factory()->create([
+            'carrera_sede_id'      => $careerCampus->carrera_sede_id,
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+        ]);
+        $this->proceso  = Process::factory()->create([
+            'ciclo_acreditacion_id' => $ciclo->ciclo_acreditacion_id,
+        ]);
+        $this->elemento = StructureElement::factory()->create([
+            'modelo_estructura_id' => $modelo->modelo_estructura_id,
+            'padre_id'             => null,
+            'activo'               => true,
+        ]);
+    }
+
+    // ─── approveElemento — excepciones ──────────────────────────────────────
+
+    public function test_approveElemento_lanza_excepcion_si_elemento_no_existe(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/no existe/i');
+
+        $this->service->approveElemento(999999, $this->proceso->proceso_id);
+    }
+
+    public function test_approveElemento_lanza_excepcion_si_ya_fue_aprobado(): void
+    {
+        // Aprobar la primera vez
+        $this->service->approveElemento($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/ya está aprobado/i');
+
+        // Segunda aprobación debe fallar
+        $this->service->approveElemento($this->elemento->elemento_id, $this->proceso->proceso_id);
+    }
+
+    // ─── approveElemento — flujo feliz ───────────────────────────────────────
+
+    public function test_approveElemento_crea_registro_en_APROBACION_ELEMENTO(): void
+    {
+        $result = $this->service->approveElemento(
+            $this->elemento->elemento_id,
+            $this->proceso->proceso_id,
+            'Comentario de prueba'
+        );
+
+        $this->assertArrayHasKey('raiz', $result);
+        $this->assertArrayHasKey('cascada', $result);
+        $this->assertEquals('aprobado', $result['raiz']->estado);
+        $this->assertEmpty($result['cascada']);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'estado'      => 'aprobado',
+        ]);
+    }
+
+    public function test_approveElemento_asigna_el_usuario_autenticado(): void
+    {
+        $this->service->approveElemento($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+        ]);
+    }
+
+    public function test_approveElemento_cascada_aprueba_hijos_activos(): void
+    {
+        $hijo1 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+        $hijo2 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+
+        $result = $this->service->approveElemento(
+            $this->elemento->elemento_id,
+            $this->proceso->proceso_id
+        );
+
+        $this->assertCount(2, $result['cascada']);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $hijo1->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $hijo2->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+    }
+
+    public function test_approveElemento_no_aprueba_hijos_inactivos(): void
+    {
+        $hijoInactivo = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => false,
+        ]);
+
+        $result = $this->service->approveElemento(
+            $this->elemento->elemento_id,
+            $this->proceso->proceso_id
+        );
+
+        $this->assertEmpty($result['cascada']);
+
+        $this->assertDatabaseMissing('APROBACION_ELEMENTO', [
+            'elemento_id' => $hijoInactivo->elemento_id,
+        ]);
+    }
+
+    // ─── rejectElemento — excepciones ────────────────────────────────────────
+
+    public function test_rejectElemento_lanza_excepcion_si_elemento_no_existe(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/no existe/i');
+
+        $this->service->rejectElemento(999999, $this->proceso->proceso_id);
+    }
+
+    public function test_rejectElemento_lanza_excepcion_si_ya_fue_rechazado(): void
+    {
+        $this->service->rejectElemento($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/ya está rechazado/i');
+
+        $this->service->rejectElemento($this->elemento->elemento_id, $this->proceso->proceso_id);
+    }
+
+    // ─── rejectElemento — flujo feliz ─────────────────────────────────────────
+
+    public function test_rejectElemento_crea_registro_en_APROBACION_ELEMENTO(): void
+    {
+        $resultado = $this->service->rejectElemento(
+            $this->elemento->elemento_id,
+            $this->proceso->proceso_id,
+            'Falta documentación',
+            now()->addDays(10)->toDateString()
+        );
+
+        $this->assertEquals('rechazado', $resultado['raiz']->estado);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'estado'      => 'rechazado',
+        ]);
+    }
+
+    // ─── recalculateParentState ───────────────────────────────────────────────
+
+    public function test_recalculateParentState_estado_aprobado_cuando_todos_hijos_aprobados(): void
+    {
+        $hijo1 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+        $hijo2 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+
+        // Crear aprobación del padre (necesaria para recalcular)
+        ElementApproval::factory()->create([
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'pendiente',
+        ]);
+
+        // Crear aprobaciones de ambos hijos como 'aprobado'
+        ElementApproval::factory()->create([
+            'elemento_id' => $hijo1->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'aprobado',
+        ]);
+        ElementApproval::factory()->create([
+            'elemento_id' => $hijo2->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'aprobado',
+        ]);
+
+        $this->service->recalculateParentState($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'estado'      => 'aprobado',
+        ]);
+    }
+
+    public function test_recalculateParentState_estado_rechazado_cuando_todos_hijos_rechazados(): void
+    {
+        $hijo = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+
+        ElementApproval::factory()->create([
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'pendiente',
+        ]);
+        ElementApproval::factory()->create([
+            'elemento_id' => $hijo->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'rechazado',
+        ]);
+
+        $this->service->recalculateParentState($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'estado'      => 'rechazado',
+        ]);
+    }
+
+    public function test_recalculateParentState_estado_incompleto_cuando_hay_mezcla(): void
+    {
+        $hijo1 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+        $hijo2 = StructureElement::factory()->create([
+            'modelo_estructura_id' => $this->elemento->modelo_estructura_id,
+            'padre_id'             => $this->elemento->elemento_id,
+            'activo'               => true,
+        ]);
+
+        ElementApproval::factory()->create([
+            'elemento_id' => $this->elemento->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'pendiente',
+        ]);
+        ElementApproval::factory()->create([
+            'elemento_id' => $hijo1->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'aprobado',
+        ]);
+        ElementApproval::factory()->create([
+            'elemento_id' => $hijo2->elemento_id,
+            'proceso_id'  => $this->proceso->proceso_id,
+            'usuario_id'  => $this->user->usuario_id,
+            'estado'      => 'rechazado',
+        ]);
+
+        $this->service->recalculateParentState($this->elemento->elemento_id, $this->proceso->proceso_id);
+
+        $this->assertDatabaseHas('APROBACION_ELEMENTO', [
+            'elemento_id' => $this->elemento->elemento_id,
+            'estado'      => 'incompleto',
+        ]);
+    }
+
+    // ─── listApprovals / getApproval ─────────────────────────────────────────
+
+    public function test_listApprovals_retorna_todos_los_registros(): void
+    {
+        ElementApproval::factory()->count(3)->create([
+            'proceso_id' => $this->proceso->proceso_id,
+            'usuario_id' => $this->user->usuario_id,
+        ]);
+
+        $result = $this->service->listApprovals();
+
+        $this->assertGreaterThanOrEqual(3, $result->count());
+    }
+
+    public function test_listApprovals_filtra_por_estado(): void
+    {
+        ElementApproval::factory()->create([
+            'proceso_id' => $this->proceso->proceso_id,
+            'usuario_id' => $this->user->usuario_id,
+            'estado'     => 'aprobado',
+        ]);
+        ElementApproval::factory()->rechazado()->create([
+            'proceso_id' => $this->proceso->proceso_id,
+            'usuario_id' => $this->user->usuario_id,
+        ]);
+
+        $result = $this->service->listApprovals('aprobado');
+
+        $this->assertTrue($result->every(fn($a) => $a->estado === 'aprobado'));
+    }
+
+    public function test_getApproval_retorna_null_si_no_existe(): void
+    {
+        $result = $this->service->getApproval(999999);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/EvidenceTest.php
+++ b/tests/Unit/EvidenceTest.php
@@ -1,91 +1,155 @@
 <?php
 
+namespace Tests\Unit;
+
+use App\Models\Comment;
+use App\Models\Component;
+use App\Models\Criterion;
+use App\Models\Dimension;
 use App\Models\Evidence;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
-it('creates evidence', function () {
-    // Prueba de creación de evidencia
-    $criterion = \App\Models\Criterion::factory()->create([
-        'componente_id' => \App\Models\Component::factory()->create([
-            'dimension_id' => \App\Models\Dimension::factory()->create()->dimension_id,
-        ])->componente_id,
-    ]);
-    $evidenceState = \App\Models\EvidenceState::factory()->create();
-    $evidence = \App\Models\Evidence::factory()->create([
-        'criterio_id' => $criterion->criterio_id,
-        'estado_evidencia_id' => $evidenceState->estado_evidencia_id,
-        'descripcion' => 'Evidencia 1',
-    ]);
-    $this->assertDatabaseHas('EVIDENCIA', [
-        'descripcion' => 'Evidencia 1',
-        'criterio_id' => $criterion->criterio_id,
-        'estado_evidencia_id' => $evidenceState->estado_evidencia_id,
-    ]);
-});
+class EvidenceTest extends TestCase
+{
+    use RefreshDatabase;
 
-it('requires descripcion field', function () {
-    // Prueba de validación: campo descripción es obligatorio
-    $dimension = \App\Models\Dimension::factory()->create();
-    $component = \App\Models\Component::factory()->create([
-        'dimension_id' => $dimension->dimension_id,
-    ]);
-    $criterion = \App\Models\Criterion::factory()->create([
-        'componente_id' => $component->componente_id,
-    ]);
-    $evidenceState = \App\Models\EvidenceState::factory()->create();
-    \App\Models\Evidence::factory()->create([
-        'criterio_id' => $criterion->criterio_id,
-        'estado_evidencia_id' => $evidenceState->estado_evidencia_id,
-        'descripcion' => null,
-    ]);
-})->throws(\Illuminate\Database\QueryException::class);
+    // ─── Helper ──────────────────────────────────────────────────────────────
 
-it('updates evidence', function () {
-    // Prueba de actualización de evidencia
-    $dimension = \App\Models\Dimension::factory()->create();
-    $component = \App\Models\Component::factory()->create([
-        'dimension_id' => $dimension->dimension_id,
-    ]);
-    $criterion = \App\Models\Criterion::factory()->create([
-        'componente_id' => $component->componente_id,
-    ]);
-    $evidenceState = \App\Models\EvidenceState::factory()->create();
-    $evidence = \App\Models\Evidence::factory()->create([
-        'criterio_id' => $criterion->criterio_id,
-        'estado_evidencia_id' => $evidenceState->estado_evidencia_id,
-        'descripcion' => 'Original',
-    ]);
-    $evidence->update(['descripcion' => 'Actualizado']);
-    $this->assertDatabaseHas('EVIDENCIA', ['descripcion' => 'Actualizado']);
-});
+    private function makeCriterion(): Criterion
+    {
+        $dimension = Dimension::factory()->create();
+        $component = Component::factory()->create(['dimension_id' => $dimension->dimension_id]);
+        return Criterion::factory()->create(['componente_id' => $component->componente_id]);
+    }
 
-it('deletes evidence', function () {
-    // Prueba de eliminación de evidencia
-    $dimension = \App\Models\Dimension::factory()->create();
-    $component = \App\Models\Component::factory()->create([
-        'dimension_id' => $dimension->dimension_id,
-    ]);
-    $criterion = \App\Models\Criterion::factory()->create([
-        'componente_id' => $component->componente_id,
-    ]);
-    $evidenceState = \App\Models\EvidenceState::factory()->create();
-    $evidence = \App\Models\Evidence::factory()->create([
-        'criterio_id' => $criterion->criterio_id,
-        'estado_evidencia_id' => $evidenceState->estado_evidencia_id,
-    ]);
-    $evidence->delete();
-    $this->assertDatabaseMissing('EVIDENCIA', ['evidencia_id' => $evidence->evidencia_id]);
-});
+    // ─── CRUD básico ─────────────────────────────────────────────────────────
 
-it('evidence belongs to criterion', function () {
-    $dimension = \App\Models\Dimension::factory()->create();
-    $component = \App\Models\Component::factory()->create([
-        'dimension_id' => $dimension->dimension_id,
-    ]);
-    $criterion = \App\Models\Criterion::factory()->create([
-        'componente_id' => $component->componente_id,
-    ]);
-    $evidence = \App\Models\Evidence::factory()->create([
-        'criterio_id' => $criterion->criterio_id,
-    ]);
-    expect($evidence->criterion->criterio_id)->toBe($criterion->criterio_id);
-});
+    public function test_creates_evidence(): void
+    {
+        $criterion = $this->makeCriterion();
+
+        Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+            'descripcion' => 'Evidencia 1',
+        ]);
+
+        $this->assertDatabaseHas('EVIDENCIA', [
+            'descripcion' => 'Evidencia 1',
+            'criterio_id' => $criterion->criterio_id,
+        ]);
+    }
+
+    public function test_requires_descripcion_field(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $criterion = $this->makeCriterion();
+
+        Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+            'descripcion' => null,
+        ]);
+    }
+
+    public function test_updates_evidence(): void
+    {
+        $criterion = $this->makeCriterion();
+
+        $evidence = Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+            'descripcion' => 'Original',
+        ]);
+        $evidence->update(['descripcion' => 'Actualizado']);
+
+        $this->assertDatabaseHas('EVIDENCIA', ['descripcion' => 'Actualizado']);
+    }
+
+    public function test_deletes_evidence(): void
+    {
+        $criterion = $this->makeCriterion();
+
+        $evidence = Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+        ]);
+        $evidence->delete();
+
+        $this->assertDatabaseMissing('EVIDENCIA', ['evidencia_id' => $evidence->evidencia_id]);
+    }
+
+    public function test_evidence_belongs_to_criterion(): void
+    {
+        $criterion = $this->makeCriterion();
+
+        $evidence = Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+        ]);
+
+        $this->assertSame($criterion->criterio_id, $evidence->criterion->criterio_id);
+    }
+
+    // ─── HU-013: relaciones y estados ────────────────────────────────────────
+
+    public function test_evidence_has_many_comments_relacion_polimorfica(): void
+    {
+        $criterion = $this->makeCriterion();
+        $evidence  = Evidence::factory()->create(['criterio_id' => $criterion->criterio_id]);
+
+        Comment::factory()->create([
+            'commentable_type' => Evidence::class,
+            'commentable_id'   => $evidence->evidencia_id,
+        ]);
+
+        $this->assertSame(1, $evidence->comments()->count());
+    }
+
+    public function test_evidence_estado_Pendiente_no_es_revisable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $criterion = $this->makeCriterion();
+        $evidence  = Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+            'estado'      => 'Pendiente',
+        ]);
+
+        $reviewer = User::factory()->create();
+        $service  = app(\App\Services\TradicionalEvidenceService::class);
+
+        $service->retroalimentar($evidence, [
+            'estado'     => 'Observada',
+            'comentario' => 'Test',
+        ], $reviewer);
+    }
+
+    public function test_evidence_estado_En_Proceso_cambia_a_Observada_tras_retroalimentar(): void
+    {
+        $criterion = $this->makeCriterion();
+        $evidence  = Evidence::factory()->create([
+            'criterio_id' => $criterion->criterio_id,
+            'estado'      => 'En Proceso',
+        ]);
+
+        $reviewer = User::factory()->create();
+        $service  = app(\App\Services\TradicionalEvidenceService::class);
+
+        $updated = $service->retroalimentar($evidence, [
+            'estado'     => 'Observada',
+            'comentario' => 'Le falta el acta firmada.',
+        ], $reviewer);
+
+        $this->assertSame('Observada', $updated->estado);
+
+        $this->assertDatabaseHas('EVIDENCIA', [
+            'evidencia_id' => $evidence->evidencia_id,
+            'estado'       => 'Observada',
+        ]);
+
+        $this->assertDatabaseHas('COMENTARIO', [
+            'usuario_id' => $reviewer->usuario_id,
+            'texto'      => 'Le falta el acta firmada.',
+        ]);
+    }
+}


### PR DESCRIPTION

- Al aprobar o rechazar un elemento estructural, se genera una notificación interna
  a los usuarios asignados a ese elemento mediante `NotificationService::createMany`.
- Aplica en cascada: si se aprueba un elemento padre, todos sus hijos activos
  también generan notificación.
- Implementado en `ElementApprovalService::approveElemento` y `rejectElemento`.

### test — HU-010: Aprobación de elementos (modelo flexible)
- `tests/Feature/ElementApprovalFeatureTest.php` — 19 tests
  Cubre: 401/403, validación 422, aprobar/rechazar con 201, cascada a hijos,
  listado y detalle de aprobaciones.
- `tests/Unit/ElementApprovalTest.php` — 15 tests
  Cubre: excepciones del servicio, cascada, recalculateParentState, listApprovals.
- `database/factories/ElementApprovalFactory.php` — factory creada.

### test — HU-013: Retroalimentación de evidencias
- `tests/Feature/RetroalimentacionFeatureTest.php` — 12 tests
- `tests/Unit/EvidenceTest.php` — 8 tests

### test — HU-030: Ciclos de acreditación
- `tests/Feature/AccreditationCycleFeatureTest.php` — 21 tests
- `tests/Unit/AccreditationCycleTest.php` — 10 tests

## Resultado de tests
85/85 tests pasando — 164 assertions ✅