### PR TITLE
fix: filtrado de solicitudes ampliacion por modelo y datos demo

### DIFF
--- a/app/Http/Controllers/GlobalFilterContextController.php
+++ b/app/Http/Controllers/GlobalFilterContextController.php
@@ -67,7 +67,7 @@ class GlobalFilterContextController extends Controller
                     $careersQuery->whereIn('carrera_sede_id', $ids);
                 }
 
-                $cyclesQuery = AccreditationCycle::query()->with(['careerCampus.career', 'careerCampus.campus']);
+                $cyclesQuery = AccreditationCycle::query()->with('modeloEstructura')->with(['careerCampus.career', 'careerCampus.campus']);
                 if ($context['career_campus_id']) {
                     $cyclesQuery->where('carrera_sede_id', $context['career_campus_id']);
                 }
@@ -93,6 +93,7 @@ class GlobalFilterContextController extends Controller
                         'nombre'                => $item->nombre,
                         'estado'                => $item->estado,
                         'carrera_sede_id'       => $item->carrera_sede_id,
+                        'modelo_tipo'           => $item->modeloEstructura?->tipo ?? null,
                     ])->values(),
                     'processes' => $processesQuery->orderByDesc('proceso_id')->get()->map(fn (Process $item) => [
                         'proceso_id'            => $item->proceso_id,

--- a/app/Services/TradicionalExtensionRequestService.php
+++ b/app/Services/TradicionalExtensionRequestService.php
@@ -20,6 +20,32 @@ use Illuminate\Support\Facades\Notification;
 class TradicionalExtensionRequestService extends AbstractExtensionRequestService
 {
     /**
+     * Obtener solicitudes de ampliación del modelo tradicional (solo evidencia_asignacion_id).
+     *
+     * Sobrescribe el método base para excluir solicitudes del modelo flexible,
+     * garantizando que solo se retornen registros tradicionales.
+     */
+    public function getAll(array $filters = []): mixed
+    {
+        $perPage      = min($filters['per_page'] ?? 15, 100);
+        $estado       = $filters['estado'] ?? null;
+        $usuarioId    = $filters['usuario_id'] ?? null;
+        $asignacionId = $filters['evidencia_asignacion_id'] ?? null;
+        $fechaDesde   = $filters['fecha_desde'] ?? null;
+        $fechaHasta   = $filters['fecha_hasta'] ?? null;
+
+        return ExtensionRequest::with(static::WITH_BASE)
+            ->whereNull('elemento_asignacion_id')
+            ->when($estado,       fn($q) => $q->where('estado', $estado))
+            ->when($usuarioId,    fn($q) => $q->where('usuario_id', $usuarioId))
+            ->when($asignacionId, fn($q) => $q->where('evidencia_asignacion_id', $asignacionId))
+            ->when($fechaDesde,   fn($q) => $q->where('created_at', '>=', $fechaDesde))
+            ->when($fechaHasta,   fn($q) => $q->where('created_at', '<=', $fechaHasta))
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage);
+    }
+
+    /**
      * Crear una nueva solicitud de ampliación para el modelo tradicional.
      *
      * Notifica por email a los encargados de acreditación de la carrera.

--- a/database/seeders/FullSystemDemoSeeder.php
+++ b/database/seeders/FullSystemDemoSeeder.php
@@ -561,7 +561,7 @@ class FullSystemDemoSeeder extends Seeder
         DB::table('SOLICITUD_AMPLIACION')->insert([
             'evidencia_asignacion_id' => $evidExt1Id,
             'usuario_id'              => $profesor->usuario_id,
-            'motivo'                  => self::TAG . ' El archivo de soporte requiere firma del coordinador y el proceso tomará más tiempo del previsto inicialmente.',
+            'motivo'                  => 'El archivo de soporte requiere firma del coordinador y el proceso tomará más tiempo del previsto inicialmente.',
             'fecha_sugerida'          => $now->copy()->addDays(30)->toDateTimeString(),
             'estado'                  => 'pendiente',
             'created_at'              => $now,
@@ -572,12 +572,12 @@ class FullSystemDemoSeeder extends Seeder
         DB::table('SOLICITUD_AMPLIACION')->insert([
             'evidencia_asignacion_id' => $evidExt2Id,
             'usuario_id'              => $profesor->usuario_id,
-            'motivo'                  => self::TAG . ' El laboratorio de informática estuvo cerrado por mantenimiento durante la semana anterior. Se solicita 10 días adicionales.',
+            'motivo'                  => 'El laboratorio de informática estuvo cerrado por mantenimiento durante la semana anterior. Se solicita 10 días adicionales.',
             'fecha_sugerida'          => $now->copy()->addDays(10)->toDateTimeString(),
             'estado'                  => 'aprobada',
             'fecha_resolucion'        => $now->copy()->subDays(2)->toDateTimeString(),
             'usuario_resolutor_id'    => $encargado->usuario_id,
-            'justificacion'           => self::TAG . ' Se aprueba la extensión. El motivo es válido y el plazo solicitado es razonable.',
+            'justificacion'           => 'Se aprueba la extensión. El motivo es válido y el plazo solicitado es razonable.',
             'created_at'              => $now->copy()->subDays(5),
             'updated_at'              => $now,
         ]);
@@ -586,12 +586,12 @@ class FullSystemDemoSeeder extends Seeder
         DB::table('SOLICITUD_AMPLIACION')->insert([
             'evidencia_asignacion_id' => $evidVencidaId,
             'usuario_id'              => $encargado->usuario_id,
-            'motivo'                  => self::TAG . ' Solicitud enviada luego de que el plazo ya había vencido sin justificación previa.',
+            'motivo'                  => 'Solicitud enviada luego de que el plazo ya había vencido sin justificación previa.',
             'fecha_sugerida'          => $now->copy()->addDays(7)->toDateTimeString(),
             'estado'                  => 'rechazada',
             'fecha_resolucion'        => $now->copy()->subDays(4)->toDateTimeString(),
             'usuario_resolutor_id'    => $encargado->usuario_id,
-            'justificacion'           => self::TAG . ' La solicitud fue presentada fuera del plazo reglamentario. No se admite extensión.',
+            'justificacion'           => 'La solicitud fue presentada fuera del plazo reglamentario. No se admite extensión.',
             'created_at'              => $now->copy()->subDays(6),
             'updated_at'              => $now,
         ]);
@@ -803,7 +803,7 @@ class FullSystemDemoSeeder extends Seeder
         DB::table('SOLICITUD_AMPLIACION_ELEMENTO')->insert([
             'elemento_asignacion_id' => $eleAsign3Id,
             'usuario_id'             => $profesor->usuario_id,
-            'motivo'                 => self::TAG . ' Pendiente la firma de validación del coordinador de área sobre la fuente de evidencia F2.1. El proceso administrativo está en trámite.',
+            'motivo'                 => 'Pendiente la firma de validación del coordinador de área sobre la fuente de evidencia F2.1. El proceso administrativo está en trámite.',
             'fecha_sugerida'         => $now->copy()->addDays(21)->toDateTimeString(),
             'estado'                 => 'pendiente',
             'created_at'             => $now,
@@ -814,12 +814,12 @@ class FullSystemDemoSeeder extends Seeder
         DB::table('SOLICITUD_AMPLIACION_ELEMENTO')->insert([
             'elemento_asignacion_id' => $eleAsign1Id,
             'usuario_id'             => $profesor->usuario_id,
-            'motivo'                 => self::TAG . ' El repositorio central estuvo fuera de servicio durante 3 días hábiles impidiendo la carga del documento.',
+            'motivo'                 => 'El repositorio central estuvo fuera de servicio durante 3 días hábiles impidiendo la carga del documento.',
             'fecha_sugerida'         => $now->copy()->addDays(7)->toDateTimeString(),
             'estado'                 => 'aprobada',
             'fecha_resolucion'       => $now->copy()->subDays(1)->toDateTimeString(),
             'usuario_resolutor_id'   => $encargado->usuario_id,
-            'justificacion'          => self::TAG . ' Incidencia técnica confirmada. Se concede la extensión de 7 días.',
+            'justificacion'          => 'Incidencia técnica confirmada. Se concede la extensión de 7 días.',
             'created_at'             => $now->copy()->subDays(4),
             'updated_at'             => $now,
         ]);


### PR DESCRIPTION
- GlobalFilterContextController: agrega modelo_tipo al catalogo de ciclos (eager load modeloEstructura) para que el frontend pueda distinguir ciclos tradicionales de ciclos flexibles
- TradicionalExtensionRequestService: agrega override de getAll() con whereNull('elemento_asignacion_id') para excluir solicitudes del modelo flexible
- FullSystemDemoSeeder: elimina prefijo [DEMO] de campos motivo y justificacion en SOLICITUD_AMPLIACION y SOLICITUD_AMPLIACION_ELEMENTO